### PR TITLE
Rename vtool_ibeis import references to vtool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ to install the software. Then the command to run the GUI is:
 On Windows / OSX I recommend using a Linux virtual machine. However, if you are
 computer savvy it is possible to build all of the requirements on from source.
 The only tricky components are installing the packages with binary
-dependencies: ``pyhesaff`` and ``vtool_ibeis``. If you have these built then
+dependencies: ``pyhesaff`` and ``wbia-vtool``. If you have these built then
 the rest of the dependencies can be installed from pypi even on OSX / Windows.
 
 

--- a/README.rst
+++ b/README.rst
@@ -489,16 +489,16 @@ Example usage
     python -m wbia.algo.hots.distinctiveness_normalizer --test-test_single_annot_distinctiveness_params --show --db GZ_ALL --aid 2
 
     # 2D Gaussian Curves
-    python -m vtool_ibeis.patch --test-test_show_gaussian_patches2 --show
+    python -m vtool.patch --test-test_show_gaussian_patches2 --show
 
     # Test Keypoint Coverage
-    python -m vtool_ibeis.coverage_kpts --test-gridsearch_kpts_coverage_mask --show
-    python -m vtool_ibeis.coverage_kpts --test-make_kpts_coverage_mask --show
+    python -m vtool.coverage_kpts --test-gridsearch_kpts_coverage_mask --show
+    python -m vtool.coverage_kpts --test-make_kpts_coverage_mask --show
 
     # Test Grid Coverage
-    python -m vtool_ibeis.coverage_grid --test-gridsearch_coverage_grid_mask --show
-    python -m vtool_ibeis.coverage_grid --test-sparse_grid_coverage --show
-    python -m vtool_ibeis.coverage_grid --test-gridsearch_coverage_grid --show
+    python -m vtool.coverage_grid --test-gridsearch_coverage_grid_mask --show
+    python -m vtool.coverage_grid --test-sparse_grid_coverage --show
+    python -m vtool.coverage_grid --test-gridsearch_coverage_grid --show
 
     # Test Spatially Constrained Scoring
     python -m wbia.algo.hots.vsone_pipeline --test-compute_query_constrained_matches --show

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -34,7 +34,7 @@ ubelt >= 0.8.7
 futures_actors
 
 utool >= 2.1.2
-vtool_ibeis >= 2.1.0
+wbia-vtool >= 2.1.0
 
 pyqt5>= 5.11.2;python_version>'2.7'  
 

--- a/super_setup.py
+++ b/super_setup.py
@@ -666,7 +666,7 @@ def make_netharn_registry(remote):
             name='vtool_ibeis', branch='master', remote=remote,
             remotes={
                 'Erotemic': 'git@github.com:Erotemic/vtool_ibeis.git',
-                'Wildbook': 'git@github.com:WildbookOrg/vtool_ibeis.git',
+                'Wildbook': 'git@github.com:WildbookOrg/wbia-vtool.git',
             },
         ),
         CommonRepo(

--- a/wbia/__main__.py
+++ b/wbia/__main__.py
@@ -58,7 +58,7 @@ def run_wbia():
     # Run the tests of other modules
     elif ub.argflag('--run-utool-tests'):
         raise Exception('Deprecated functionality')
-    elif ub.argflag('--run-vtool_ibeis-tests'):
+    elif ub.argflag('--run-vtool-tests'):
         raise Exception('Deprecated functionality')
     elif ub.argflag(('--run-wbia-tests', '--run-tests')):
         raise Exception('Deprecated functionality')
@@ -111,7 +111,7 @@ def run_wbia():
         ./dist/wbia/IBEISApp --tmod utool.util_str --test-align:0
         ./dist/IBEIS.app/Contents/MacOS/IBEISApp --tmod utool.util_str --test-align:0
         ./dist/IBEIS.app/Contents/MacOS/IBEISApp --run-utool-tests
-        ./dist/IBEIS.app/Contents/MacOS/IBEISApp --run-vtool_ibeis-tests
+        ./dist/IBEIS.app/Contents/MacOS/IBEISApp --run-vtool-tests
         """
         print('[wbia] Testing module')
         mod_alias_list = {

--- a/wbia/_devcmds_wbia.py
+++ b/wbia/_devcmds_wbia.py
@@ -11,7 +11,7 @@ from os.path import split, join, expanduser
 from wbia.plottool import draw_func2 as df2
 import numpy as np
 import utool
-import vtool_ibeis.keypoint as ktool
+import vtool.keypoint as ktool
 from wbia import sysres
 from wbia.other import ibsfuncs
 from wbia.dbio import ingest_hsdb

--- a/wbia/algo/detect/darknet.py
+++ b/wbia/algo/detect/darknet.py
@@ -4,7 +4,7 @@ Interface to Darknet object proposals.
 """
 from __future__ import absolute_import, division, print_function
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from six.moves import zip
 import tempfile
 import subprocess

--- a/wbia/algo/detect/fasterrcnn.py
+++ b/wbia/algo/detect/fasterrcnn.py
@@ -4,7 +4,7 @@ Interface to Faster R-CNN object proposals.
 """
 from __future__ import absolute_import, division, print_function
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from six.moves import zip, range
 from os.path import abspath, dirname, expanduser, join, exists  # NOQA
 import numpy as np

--- a/wbia/algo/detect/randomforest.py
+++ b/wbia/algo/detect/randomforest.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 from os.path import exists, join
 from wbia.algo.detect import grabmodels
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from six.moves import zip, map
 import cv2
 import random

--- a/wbia/algo/detect/selectivesearch.py
+++ b/wbia/algo/detect/selectivesearch.py
@@ -4,7 +4,7 @@ Interface to Selective Search object proposals.
 """
 from __future__ import absolute_import, division, print_function
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from six.moves import zip
 import tempfile
 import subprocess

--- a/wbia/algo/detect/ssd.py
+++ b/wbia/algo/detect/ssd.py
@@ -4,7 +4,7 @@ Interface to SSD object proposals.
 """
 from __future__ import absolute_import, division, print_function
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from six.moves import zip
 from os.path import abspath, dirname, expanduser, join, exists  # NOQA
 import numpy as np

--- a/wbia/algo/detect/yolo.py
+++ b/wbia/algo/detect/yolo.py
@@ -4,7 +4,7 @@ Interface to pydarknet yolo object detection.
 """
 from __future__ import absolute_import, division, print_function
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from six.moves import zip
 (print, rrr, profile) = ut.inject2(__name__, '[yolo]')
 

--- a/wbia/algo/graph/demo.py
+++ b/wbia/algo/graph/demo.py
@@ -470,7 +470,7 @@ def demodata_infr(**kwargs):
         }
     """
     import networkx as nx
-    import vtool_ibeis as vt
+    import vtool as vt
     from wbia.algo.graph import nx_utils
 
     def kwalias(*args):

--- a/wbia/algo/graph/mixin_groundtruth.py
+++ b/wbia/algo/graph/mixin_groundtruth.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import pandas as pd
 from wbia.algo.graph.nx_utils import ensure_multi_index
 from wbia.algo.graph.state import POSTV, NEGTV, INCMP

--- a/wbia/algo/graph/mixin_helpers.py
+++ b/wbia/algo/graph/mixin_helpers.py
@@ -5,7 +5,7 @@ import networkx as nx
 import operator
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from wbia import constants as const
 from wbia.algo.graph.state import POSTV, NEGTV, INCMP, UNREV, UNKWN
 from wbia.algo.graph.state import SAME, DIFF, NULL  # NOQA
@@ -540,7 +540,7 @@ class DummyEdges(object):
             weights = np.ones(len(avail_uv))
 
             if 'view_weight' in enabled_heuristics:
-                from vtool_ibeis import _rhomb_dist
+                from vtool import _rhomb_dist
                 view_edge = [(node_to_view[u], node_to_view[v])
                              for (u, v) in avail_uv]
                 view_weight = np.array([

--- a/wbia/algo/graph/mixin_matching.py
+++ b/wbia/algo/graph/mixin_matching.py
@@ -6,7 +6,7 @@ import utool as ut
 import pandas as pd
 import itertools as it
 import networkx as nx
-import vtool_ibeis as vt
+import vtool as vt
 from os.path import join  # NOQA
 from wbia.algo.graph import nx_utils as nxu
 from wbia.algo.graph.nx_utils import e_

--- a/wbia/algo/graph/mixin_viz.py
+++ b/wbia/algo/graph/mixin_viz.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 import warnings
 import utool as ut
-import vtool_ibeis as vt  # NOQA
+import vtool as vt  # NOQA
 import six
 import networkx as nx
 from wbia.algo.graph.state import (POSTV, NEGTV, INCMP, UNREV, UNKWN)

--- a/wbia/algo/graph/mixin_wbia.py
+++ b/wbia/algo/graph/mixin_wbia.py
@@ -4,7 +4,7 @@ import networkx as nx
 import pandas as pd
 import utool as ut
 import numpy as np
-import vtool_ibeis as vt  # NOQA
+import vtool as vt  # NOQA
 import six
 from wbia.algo.graph import nx_utils as nxu
 from wbia.algo.graph.state import POSTV, NEGTV, INCMP, UNREV, UNKWN  # NOQA

--- a/wbia/algo/graph/nx_utils.py
+++ b/wbia/algo/graph/nx_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import utool as ut
 import networkx as nx
 import itertools as it
-import vtool_ibeis as vt  # NOQA
+import vtool as vt  # NOQA
 # import wbia.algo.graph.nx_edge_kconnectivity as nx_ec
 from wbia.algo.graph import nx_edge_augmentation as nx_aug
 from collections import defaultdict

--- a/wbia/algo/hots/chip_match.py
+++ b/wbia/algo/hots/chip_match.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import copy
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from os.path import join
 from operator import xor
 import six
@@ -1535,7 +1535,7 @@ class _ChipMatchConvenienceGetter(object):
             >>> result = ('info_ = %s' % (ut.repr3(info_, precision=2),))
             >>> print(result)
         """
-        import vtool_ibeis as vt
+        import vtool as vt
         if flags is None:
             flags = [True] * len(cm.daid_list)
             # flags = cm.score_list > 0

--- a/wbia/algo/hots/name_scoring.py
+++ b/wbia/algo/hots/name_scoring.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from six.moves import zip, range, map  # NOQA
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import utool as ut
 import itertools
 from wbia.algo.hots import hstypes

--- a/wbia/algo/hots/neighbor_index.py
+++ b/wbia/algo/hots/neighbor_index.py
@@ -10,8 +10,8 @@ from __future__ import absolute_import, division, print_function
 import six
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
-from vtool_ibeis._pyflann_backend import pyflann as pyflann
+import vtool as vt
+from vtool._pyflann_backend import pyflann as pyflann
 # import itertools as it
 #import lockfile
 from os.path import basename

--- a/wbia/algo/hots/nn_weights.py
+++ b/wbia/algo/hots/nn_weights.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import functools
 from wbia.algo.hots import hstypes
 from wbia.algo.hots import _pipeline_helpers as plh
@@ -415,7 +415,7 @@ def lnbnn_fn(vdist, ndist):
         >>> PdiC, PdiCbar = sympy.symbols('PdiC, PdiCbar')
         >>> oddsC = log(PdiC / PdiCbar)
         >>> sympy.simplify(oddsC)
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> vt.check_expr_eq(oddsC, log(PdiC) - log(PdiCbar))
 
 
@@ -489,7 +489,7 @@ def bar_l2_fn(vdist, ndist):
 def loglnbnn_fn(vdist, ndist):
     r"""
     Ignore:
-        import vtool_ibeis as vt
+        import vtool as vt
         vt.check_expr_eq('log(d) - log(n)', 'log(d / n)')   # True
         vt.check_expr_eq('log(d) / log(n)', 'log(d - n)')
 

--- a/wbia/algo/hots/pipeline.py
+++ b/wbia/algo/hots/pipeline.py
@@ -44,7 +44,7 @@ TODO:
 from __future__ import absolute_import, division, print_function, unicode_literals
 from six.moves import zip, range, map
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 from wbia.algo.hots import hstypes
 from wbia.algo.hots import chip_match
 from wbia.algo.hots import nn_weights

--- a/wbia/algo/hots/query_request.py
+++ b/wbia/algo/hots/query_request.py
@@ -11,7 +11,7 @@ from os.path import join
 from wbia import dtool
 import itertools as it
 import hashlib
-import vtool_ibeis as vt
+import vtool as vt
 import utool as ut
 import numpy as np
 from wbia.algo.hots import neighbor_index_cache

--- a/wbia/algo/hots/requery_knn.py
+++ b/wbia/algo/hots/requery_knn.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import itertools as it
 from six.moves import range, zip, map  # NOQA
 (print, rrr, profile) = ut.inject2(__name__)

--- a/wbia/algo/hots/scoring.py
+++ b/wbia/algo/hots/scoring.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import utool as ut
 from wbia.algo.hots import _pipeline_helpers as plh  # NOQA
 print, rrr, profile = ut.inject2(__name__)

--- a/wbia/algo/preproc/occurrence_blackbox.py
+++ b/wbia/algo/preproc/occurrence_blackbox.py
@@ -407,7 +407,7 @@ def cluster_timespace_sec(posixtimes, latlons, thresh_sec=5, km_per_sec=KM_PER_S
     # Cluster nan distributions differently
     X_bools = ~np.isnan(X_data)
     group_id = (X_bools * np.power(2, [2, 1, 0])).sum(axis=1)
-    import vtool_ibeis as vt
+    import vtool as vt
     unique_ids, groupxs = vt.group_indices(group_id)
     grouped_labels = []
     for xs in groupxs:

--- a/wbia/algo/preproc/preproc_annot.py
+++ b/wbia/algo/preproc/preproc_annot.py
@@ -7,7 +7,7 @@ from six.moves import zip, range, filter, map  # NOQA
 import six
 import utool as ut
 import uuid
-from vtool_ibeis import geometry
+from vtool import geometry
 (print, rrr, profile) = ut.inject2(__name__, '[preproc_annot]')
 
 

--- a/wbia/algo/preproc/preproc_image.py
+++ b/wbia/algo/preproc/preproc_image.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os
 from os.path import splitext, basename, isabs
 import warnings
-import vtool_ibeis.exif as vtexif
+import vtool.exif as vtexif
 import utool as ut
 import six
 (print, rrr, profile) = ut.inject2(__name__)
@@ -193,7 +193,7 @@ def parse_imageinfo(gpath):
 #     Example0:
 #         >>> # ENABLE_DOCTEST
 #         >>> from wbia.algo.preproc.preproc_image import *   # NOQA
-#         >>> from vtool_ibeis.tests import grabdata
+#         >>> from vtool.tests import grabdata
 #         >>> gpath_list = grabdata.get_test_gpaths(ndata=3) + ['doesnotexist.jpg']
 #         >>> params_list = list(add_images_params_gen(gpath_list))
 #         >>> assert str(params_list[0][0]) == '66ec193a-1619-b3b6-216d-1784b4833b61', 'UUID gen method changed'

--- a/wbia/algo/preproc/preproc_occurrence.py
+++ b/wbia/algo/preproc/preproc_occurrence.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 from six.moves import zip, map, range
 from scipy.spatial import distance
 import scipy.cluster.hierarchy
@@ -289,7 +289,7 @@ def group_images_by_label(label_arr, gid_arr):
     Output: Length M list of unique labels, and lenth M list of lists of ids
     """
     # Reverse the image to cluster index mapping
-    import vtool_ibeis as vt
+    import vtool as vt
     labels_, groupxs_ = vt.group_indices(label_arr)
     sortx = np.array(list(map(len, groupxs_))).argsort()[::-1]
     labels  = labels_.take(sortx, axis=0)
@@ -442,7 +442,7 @@ def plot_gps_html(gps_list):
     import wbia.plottool as pt
     import gmplot
     import matplotlib as mpl
-    import vtool_ibeis as vt
+    import vtool as vt
     pt.qt4ensure()
 
     lat = gps_list.T[0]

--- a/wbia/algo/smk/inverted_index.py
+++ b/wbia/algo/smk/inverted_index.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from six.moves import zip, range
 from wbia import dtool
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 from wbia.algo.smk import smk_funcs
 from wbia.control.controller_inject import register_preprocs

--- a/wbia/algo/smk/pickle_flann.py
+++ b/wbia/algo/smk/pickle_flann.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
-from vtool_ibeis._pyflann_backend import pyflann as pyflann
+from vtool._pyflann_backend import pyflann as pyflann
 import utool as ut
 import uuid
 import six

--- a/wbia/algo/smk/script_smk.py
+++ b/wbia/algo/smk/script_smk.py
@@ -287,7 +287,7 @@ def load_oxford_2007():
     """
     from os.path import join, basename, splitext
     import pandas as pd
-    import vtool_ibeis as vt
+    import vtool as vt
     dbdir = ut.truepath('/raid/work/Oxford/')
     data_fpath0 = join(dbdir, 'data_2007.pkl')
 
@@ -389,7 +389,7 @@ def load_oxford_2013():
     from yael.ynumpy import fvecs_read
     from yael.yutils import load_ext
     import scipy.io
-    import vtool_ibeis as vt
+    import vtool as vt
     from os.path import join
 
     dbdir = ut.truepath('/raid/work/Oxford/')
@@ -598,7 +598,7 @@ def run_asmk_script():
     # ================
     # PRE-PROCESS
     # ================
-    import vtool_ibeis as vt
+    import vtool as vt
 
     # Alias names to avoid errors in interactive sessions
     proc_vecs = raw_vecs
@@ -732,7 +732,7 @@ def run_asmk_script():
     percent_stats = ut.get_stats(percent_list)
     print('percent_stats = %s' % (ut.repr4(percent_stats),))
 
-    import vtool_ibeis as vt
+    import vtool as vt
     query_kpts = vt.zipcompress(query_super_kpts, query_flags_list, axis=0)
     query_vecs = vt.zipcompress(query_super_vecs, query_flags_list, axis=0)
     query_wxs = vt.zipcompress(query_super_wxs, query_flags_list, axis=0)
@@ -959,7 +959,7 @@ def ensure_tf(X):
 
 
 def bow_vector(X, wx_to_weight, nwords):
-    import vtool_ibeis as vt
+    import vtool as vt
     wxs = sorted(list(X.wx_set))
     tf = np.array(ut.take(X.termfreq, wxs))
     idf = np.array(ut.take(wx_to_weight, wxs))
@@ -1055,7 +1055,7 @@ def verify_score():
 
 def kpts_inside_bbox(kpts, bbox, only_xy=False):
     # Use keypoint extent to filter out what is in query
-    import vtool_ibeis as vt
+    import vtool as vt
     xys = kpts[:, 0:2]
     if only_xy:
         flags = vt.point_inside_bbox(xys.T, bbox)
@@ -1101,7 +1101,7 @@ def oxford_conic_test():
     A, B, C = [0.016682, 0.001693, 0.014927]
     A, B, C = [0.010141, -1.1e-05, 0.02863]
     Z = np.array([[A, B], [B, C]])
-    import vtool_ibeis as vt
+    import vtool as vt
     invV = vt.decompose_Z_to_invV_2x2(Z)  # NOQA
     invV = vt.decompose_Z_to_invV_mats2x2(np.array([Z]))  # NOQA
     # seems ok
@@ -1178,7 +1178,7 @@ def show_data_image(data_uri_order, i, offset_list, all_kpts, all_vecs):
     """
     i = 12
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     from os.path import join
     imgdir = ut.truepath('/raid/work/Oxford/oxbuild_images')
     gpath = join(imgdir,  data_uri_order[i] + '.jpg')
@@ -1199,7 +1199,7 @@ def check_image_sizes(data_uri_order, all_kpts, offset_list):
     """
     Check if any keypoints go out of bounds wrt their associated images
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     from os.path import join
     imgdir = ut.truepath('/raid/work/Oxford/oxbuild_images')
     gpath_list = [join(imgdir, imgid + '.jpg') for imgid in data_uri_order]

--- a/wbia/algo/smk/smk_funcs.py
+++ b/wbia/algo/smk/smk_funcs.py
@@ -61,7 +61,7 @@ References:
 from __future__ import absolute_import, division, print_function, unicode_literals
 from six.moves import zip
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 (print, rrr, profile) = ut.inject2(__name__)
 

--- a/wbia/algo/smk/vocab_indexer.py
+++ b/wbia/algo/smk/vocab_indexer.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 from wbia import dtool
 import utool as ut
-import vtool_ibeis as vt
-from vtool_ibeis._pyflann_backend import pyflann as pyflann
+import vtool as vt
+from vtool._pyflann_backend import pyflann as pyflann
 from wbia.algo.smk import pickle_flann
 import numpy as np
 import warnings

--- a/wbia/algo/verif/clf_helpers.py
+++ b/wbia/algo/verif/clf_helpers.py
@@ -887,7 +887,7 @@ class ClfResult(ut.NiceRepr):
         return pos_threshes
 
     def report_thresholds(res, warmup=200):
-        # import vtool_ibeis as vt
+        # import vtool as vt
         ut.cprint('Threshold Report', 'yellow')
         y_test_bin = res.target_bin_df.values
         # y_test_enc = y_test_bin.argmax(axis=1)
@@ -1021,7 +1021,7 @@ class ClfResult(ut.NiceRepr):
         return report
 
     def confusions(res, class_name):
-        import vtool_ibeis as vt
+        import vtool as vt
         y_test_bin = res.target_bin_df.values
         clf_probs = res.probs_df.values
         k = res.class_names.index(class_name)
@@ -1030,7 +1030,7 @@ class ClfResult(ut.NiceRepr):
         return confusions
 
     def ishow_roc(res):
-        import vtool_ibeis as vt
+        import vtool as vt
         import wbia.plottool as pt
         ut.qtensure()
         y_test_bin = res.target_bin_df.values
@@ -1062,7 +1062,7 @@ class ClfResult(ut.NiceRepr):
         pass
 
     def show_roc(res, class_name, **kwargs):
-        import vtool_ibeis as vt
+        import vtool as vt
         labels = res.target_bin_df[class_name].values
         probs = res.probs_df[class_name].values
         confusions = vt.ConfusionMetrics().fit(probs, labels)
@@ -1086,7 +1086,7 @@ class ClfResult(ut.NiceRepr):
 
     def confusions_ovr(res):
         # one_vs_rest confusions
-        import vtool_ibeis as vt
+        import vtool as vt
         res.augment_if_needed()
         for k in range(res.y_test_bin.shape[1]):
             class_k_truth = res.y_test_bin.T[k]

--- a/wbia/algo/verif/oldvsone.py
+++ b/wbia/algo/verif/oldvsone.py
@@ -46,7 +46,7 @@ def demo_single_pairwise_feature_vector():
         >>> match = demo_single_pairwise_feature_vector()
         >>> print(match)
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia
     ibs = wbia.opendb('testdb1')
     qaid, daid = 1, 2

--- a/wbia/algo/verif/pairfeat.py
+++ b/wbia/algo/verif/pairfeat.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 import ubelt as ub
 import pandas as pd

--- a/wbia/algo/verif/torch/netmath.py
+++ b/wbia/algo/verif/torch/netmath.py
@@ -1,6 +1,6 @@
 import utool as ut
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import six
 import torch
 # from torch.autograd import Variable  # NOQA

--- a/wbia/algo/verif/verifier.py
+++ b/wbia/algo/verif/verifier.py
@@ -5,7 +5,7 @@ import pandas as pd
 import utool as ut
 from wbia.algo.verif import pairfeat
 from wbia.algo.verif import sklearn_utils
-import vtool_ibeis as vt
+import vtool as vt
 # import itertools as it
 # from os.path import join
 print, rrr, profile = ut.inject2(__name__)

--- a/wbia/algo/verif/vsone.py
+++ b/wbia/algo/verif/vsone.py
@@ -15,7 +15,7 @@ import utool as ut
 import ubelt as ub
 import itertools as it
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 from wbia import dtool as dt
 import six  # NOQA
 import hashlib

--- a/wbia/annots.py
+++ b/wbia/annots.py
@@ -258,7 +258,7 @@ class Annots(BASE):
 
     #@property
     def get_speeds(self):
-        #import vtool_ibeis as vt
+        #import vtool as vt
         edges = self.get_aidpairs()
         speeds = self._ibs.get_annotpair_speeds(edges)
         #edges = vt.pdist_indicies(len(annots))

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -1143,7 +1143,7 @@ class IBEISController(BASE_CLASS):
         #if ibs.get_dbname() == 'Oxford':
         #    pass
         #else:
-        import vtool_ibeis as vt
+        import vtool as vt
         if hasattr(ibs, 'force_icon_aid'):
             aid = ibs.force_icon_aid
         if aid is None:

--- a/wbia/control/manual_annot_funcs.py
+++ b/wbia/control/manual_annot_funcs.py
@@ -114,7 +114,7 @@ def compute_annot_visual_semantic_uuids(ibs, gid_list, include_preprocess=False,
 def _add_annots_preprocess(ibs, gid_list, bbox_list=None, theta_list=None, vert_list=None,
                            species_list=None, species_rowid_list=None, viewpoint_list=None,
                            nid_list=None, name_list=None, skip_cleaning=False, **kwargs):
-    from vtool_ibeis import geometry
+    from vtool import geometry
 
     # BBOXES / VERTS
     # For import only, we can specify both by setting import_override to True
@@ -1792,7 +1792,7 @@ def get_annot_rotated_verts(ibs, aid_list):
         Method: GET
         URL:    /api/annot/vert/rotated/
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     vert_list = ibs.get_annot_verts(aid_list)
     theta_list = ibs.get_annot_thetas(aid_list)
     # Convex bounding boxes for verticies
@@ -2817,7 +2817,7 @@ def set_annot_bboxes(ibs, aid_list, bbox_list, delete_thumbs=True, **kwargs):
         Method: PUT
         URL:    /api/annot/bbox/
     """
-    from vtool_ibeis import geometry
+    from vtool import geometry
     # changing the bboxes also changes the bounding polygon
     vert_list = geometry.verts_list_from_bboxes_list(bbox_list)
     # naively overwrite the bounding polygon with a rectangle - for now trust the user!
@@ -3199,7 +3199,7 @@ def set_annot_verts(ibs, aid_list, verts_list,
     with ut.Timer('set_annot_verts'):
 
         with ut.Timer('set_annot_verts...config'):
-            from vtool_ibeis import geometry
+            from vtool import geometry
             nInput = len(aid_list)
             # Compute data to set
             if isinstance(verts_list, np.ndarray):

--- a/wbia/control/manual_feat_funcs.py
+++ b/wbia/control/manual_feat_funcs.py
@@ -115,7 +115,7 @@ def get_annot_kpts(ibs, aid_list, ensure=True, eager=True, nInput=None,
         >>> # SLOW_DOCTEST
         >>> # xdoctest: +SKIP
         >>> from wbia.control.manual_feat_funcs import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> import numpy as np
         >>> import wbia
         >>> import wbia.viz.interact

--- a/wbia/control/manual_image_funcs.py
+++ b/wbia/control/manual_image_funcs.py
@@ -24,7 +24,7 @@ from wbia.control.controller_inject import make_ibs_register_decorator
 from os.path import join, exists, isabs
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from wbia.web import routes_ajax
 import six
 print, rrr, profile = ut.inject2(__name__)
@@ -994,7 +994,7 @@ def _set_image_orientation(ibs, gid_list, orientation_list):
 
 
 def update_image_rotate_90(ibs, gid_list, direction):
-    from vtool_ibeis.exif import (ORIENTATION_DICT_INVERSE, ORIENTATION_ORDER_LIST,
+    from vtool.exif import (ORIENTATION_DICT_INVERSE, ORIENTATION_ORDER_LIST,
                             ORIENTATION_UNDEFINED, ORIENTATION_000)
 
     def _update_bounding_boxes(gid, val):
@@ -1849,7 +1849,7 @@ def get_image_orientation_str(ibs, gid_list):
         Method: GET
         URL:    /api/image/orientation/str/
     """
-    from vtool_ibeis.exif import ORIENTATION_DICT
+    from vtool.exif import ORIENTATION_DICT
     orient_list = ibs.get_image_orientation(gid_list)
     orient_str = [ ORIENTATION_DICT[orient] for orient in orient_list ]
     return orient_str

--- a/wbia/control/manual_name_funcs.py
+++ b/wbia/control/manual_name_funcs.py
@@ -14,7 +14,7 @@ import six  # NOQA
 from wbia import constants as const
 from wbia.other import ibsfuncs
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 from wbia.control import accessor_decors, controller_inject  # NOQA
 import utool as ut
 from wbia.control.controller_inject import make_ibs_register_decorator
@@ -434,7 +434,7 @@ def get_name_aids(ibs, nid_list, enable_unknown_fix=True, is_staged=False):
     ORDER BY name_rowid ASC
 
 
-    import vtool_ibeis as vt
+    import vtool as vt
     vt
     vt.aid_list[0]
 

--- a/wbia/control/manual_part_funcs.py
+++ b/wbia/control/manual_part_funcs.py
@@ -157,7 +157,7 @@ def add_parts(ibs, aid_list, bbox_list=None, theta_list=None,
         URL:    /api/part/
     """
     #ut.embed()
-    from vtool_ibeis import geometry
+    from vtool import geometry
     if ut.VERBOSE:
         print('[ibs] adding parts')
     # Prepare the SQL input
@@ -537,7 +537,7 @@ def get_part_rotated_verts(ibs, part_rowid_list):
         Method: GET
         URL:    /api/part/vert/rotated/
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     vert_list = ibs.get_part_verts(part_rowid_list)
     theta_list = ibs.get_part_thetas(part_rowid_list)
     # Convex bounding boxes for verticies
@@ -932,7 +932,7 @@ def set_part_bboxes(ibs, part_rowid_list, bbox_list):
         Method: PUT
         URL:    /api/part/bbox/
     """
-    from vtool_ibeis import geometry
+    from vtool import geometry
     # changing the bboxes also changes the bounding polygon
     vert_list = geometry.verts_list_from_bboxes_list(bbox_list)
     # naively overwrite the bounding polygon with a rectangle - for now trust the user!
@@ -1048,7 +1048,7 @@ def set_part_verts(ibs, part_rowid_list, verts_list,
         Method: PUT
         URL:    /api/part/vert/
     """
-    from vtool_ibeis import geometry
+    from vtool import geometry
     nInput = len(part_rowid_list)
     # Compute data to set
     if isinstance(verts_list, np.ndarray):

--- a/wbia/control/manual_review_funcs.py
+++ b/wbia/control/manual_review_funcs.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import six  # NOQA
 from six.moves import zip, map, reduce
 #import numpy as np
-#import vtool_ibeis as vt
+#import vtool as vt
 import numpy as np
 import ubelt as ub  # NOQA
 from wbia import constants as const

--- a/wbia/control/manual_species_funcs.py
+++ b/wbia/control/manual_species_funcs.py
@@ -11,7 +11,7 @@ import functools
 import six  # NOQA
 from six.moves import range, zip, map  # NOQA
 #import numpy as np
-#import vtool_ibeis as vt
+#import vtool as vt
 import numpy as np
 from wbia import constants as const
 from wbia.control import accessor_decors, controller_inject  # NOQA

--- a/wbia/control/manual_wbiacontrol_funcs.py
+++ b/wbia/control/manual_wbiacontrol_funcs.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import six  # NOQA
 import utool as ut  # NOQA
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 #from wbia import constants as const
 from wbia.control import accessor_decors  # NOQA
 from wbia.control.controller_inject import make_ibs_register_decorator

--- a/wbia/core_annots.py
+++ b/wbia/core_annots.py
@@ -48,10 +48,10 @@ Setup:
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 from six.moves import zip
-from vtool_ibeis import image_filters
+from vtool import image_filters
 from wbia import dtool
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 import cv2
 import wbia.constants as const
@@ -696,7 +696,7 @@ def compute_probchip(depc, aid_list, config=None):
     """
     print('[core] COMPUTING FEATWEIGHTS')
     print('config = %r' % (config,))
-    import vtool_ibeis as vt
+    import vtool as vt
 
     ibs = depc.controller
 

--- a/wbia/core_images.py
+++ b/wbia/core_images.py
@@ -37,7 +37,7 @@ from six.moves import zip
 from wbia import dtool
 import utool as ut
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import cv2
 from wbia.control.controller_inject import register_preprocs
 import sys

--- a/wbia/dbio/export_subset.py
+++ b/wbia/dbio/export_subset.py
@@ -678,7 +678,7 @@ def fix_annotmatch_pzmaster1():
     # # pd.unique(annotmatch['annotmatch_evidence_decision'])
     # from wbia.gui import inspect_gui
     # inspect_gui.show_vsone_tuner(ibs, aid1, aid2)
-    # from vtool_ibeis import inspect_matches
+    # from vtool import inspect_matches
 
     # aid1, aid2 = 2108, 2040
 

--- a/wbia/dbio/ingest_database.py
+++ b/wbia/dbio/ingest_database.py
@@ -38,7 +38,7 @@ from os.path import relpath, dirname, exists, join, realpath, basename, abspath
 from wbia.other import ibsfuncs
 from wbia import constants as const
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import parse
 
 (print, rrr, profile) = ut.inject2(__name__)

--- a/wbia/dev.py
+++ b/wbia/dev.py
@@ -142,7 +142,7 @@ def tune_flann(ibs, qaid_list, daid_list=None):
     all_aids = ibs.get_valid_aids()
     vecs = np.vstack(ibs.get_annot_vecs(all_aids))
     print('Tunning flann for species={species}:'.format(species=ibs.get_database_species(all_aids)))
-    import vtool_ibeis as vt
+    import vtool as vt
     tuned_params = vt.tune_flann(vecs,
                                  target_precision=.98,
                                  build_weight=0.05,
@@ -874,7 +874,7 @@ def ggr_random_name_splits():
                              ibs.get_name_aids(remain_unique_nids)]
 
     sample_size = 75
-    import vtool_ibeis as vt
+    import vtool as vt
     vt.calc_sample_from_error_bars(.05, pop, conf_level=.95, prior=.05)
 
     remain_rand_idxs = ut.random_indexes(len(remain_grouped_annots), seed=3340258)

--- a/wbia/dtool/base.py
+++ b/wbia/dtool/base.py
@@ -929,7 +929,7 @@ class VsOneSimilarityRequest(BaseRequest, AnnotSimiliarity):
 
         # vsone hack (i,j) same as (j,i)
         if request._symmetric:
-            import vtool_ibeis as vt
+            import vtool as vt
             directed_edges = np.array(parent_rowids)
             undirected_edges = vt.to_undirected_edges(directed_edges)
             edge_ids = vt.compute_unique_data_ids(undirected_edges)

--- a/wbia/dtool/example_depcache.py
+++ b/wbia/dtool/example_depcache.py
@@ -207,7 +207,7 @@ def testdata_depc(fname=None):
     """
 
     from wbia import dtool
-    import vtool_ibeis as vt
+    import vtool as vt
     gpath_list = ut.lmap(ut.grab_test_imgpath, ut.get_valid_test_imgkeys(),
                          verbose=False)
 
@@ -362,7 +362,7 @@ def testdata_depc(fname=None):
             tablename='chipmask', parents=[dummy_root], colnames=['size', 'mask'],
             coltypes=[(int, int), ('extern', vt.imread, vt.imwrite)])
         def dummy_manual_chipmask(depc, parent_rowids, config=None):
-            import vtool_ibeis as vt
+            import vtool as vt
             from wbia.plottool import interact_impaint
             mask_dpath = join(depc.cache_dpath, 'ManualChipMask')
             ut.ensuredir(mask_dpath)

--- a/wbia/dtool/old_stuff.py
+++ b/wbia/dtool/old_stuff.py
@@ -555,8 +555,8 @@
 #         >>> ut.show_if_requested()
 #     """
 #     from wbia import dtool
-#     import vtool_ibeis as vt
-#     from vtool_ibeis import fontdemo
+#     import vtool as vt
+#     from vtool import fontdemo
 
 #     # put the test cache in the dtool repo
 #     dtool_repo = dirname(ut.get_module_dir(dtool))

--- a/wbia/expt/experiment_drawing.py
+++ b/wbia/expt/experiment_drawing.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from os.path import join
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from wbia.expt import draw_helpers
 from six.moves import map, range, reduce
 print, rrr, profile = ut.inject2(__name__)
@@ -160,7 +160,7 @@ def scorediff(ibs, testres, f=None, verbose=None):
                 pt.set_ylabel('score diff')
 
             def on_click_inside(self, event, ex):
-                import vtool_ibeis as vt
+                import vtool as vt
                 #ax = event.inaxes
                 #for l in ax.get_lines():
                 #    print(l.get_label())
@@ -240,7 +240,7 @@ def draw_annot_scoresep(ibs, testres, f=None, verbose=None):
         IPython.get_ipython().magic('pylab qt4')
     """
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     from wbia.expt import cfghelpers
     if ut.VERBOSE:
         print('[dev] draw_annot_scoresep')
@@ -790,7 +790,7 @@ def temp_num_exmaples_cmc():
     pt.adjust_subplots(bottom=.15, top=.9, left=.2)
     fpath = 'cmc-dpername-combined.png'
     fig.savefig(fpath, transparent=True, edgecolor='none')
-    import vtool_ibeis as vt
+    import vtool as vt
     vt.clipwhite_ondisk(fpath, fpath, verbose=True)
     ut.startfile(fpath)
 
@@ -875,7 +875,7 @@ def temp_multidb_cmc():
     fig.set_size_inches(*((1.5 * np.array([4, 3])).tolist()))
     pt.adjust_subplots(bottom=.15)
     fig.savefig('cmc-combined.png', transparent=True, edgecolor='none')
-    import vtool_ibeis as vt
+    import vtool as vt
     vt.clipwhite_ondisk('cmc-combined.png', 'cmc-combined.png', verbose=True)
     ut.startfile('cmc-combined.png')
 

--- a/wbia/expt/test_result.py
+++ b/wbia/expt/test_result.py
@@ -5,7 +5,7 @@ import six
 import copy
 import operator
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 import itertools as it
 from functools import partial
@@ -1997,7 +1997,7 @@ class TestResult(ut.NiceRepr):
             >>> ut.show_if_requested()
         """
         import wbia.plottool as pt
-        import vtool_ibeis as vt
+        import vtool as vt
 
         # dont look at filtered cases
         ibs = testres.ibs
@@ -2148,7 +2148,7 @@ class TestResult(ut.NiceRepr):
         rectify with experiment_drawing
         """
         #import wbia.plottool as pt
-        import vtool_ibeis as vt
+        import vtool as vt
         if ut.VERBOSE:
             print('[dev] FIX DUPLICATE CODE find_thresh_cutoff')
         #from wbia.expt import cfghelpers

--- a/wbia/gui/guiback.py
+++ b/wbia/gui/guiback.py
@@ -3649,8 +3649,8 @@ class MainWindowBackend(GUIBACK_BASE):
 
     @slot_()
     def run_vtool_tests(back):
-        import vtool_ibeis.tests.run_tests
-        vtool_ibeis.tests.run_tests.run_tests()
+        import vtool.tests.run_tests
+        vtool.tests.run_tests.run_tests()
 
     @slot_()
     def assert_modules(back):

--- a/wbia/gui/id_review_api.py
+++ b/wbia/gui/id_review_api.py
@@ -92,7 +92,7 @@ def get_review_edges(cm_list, ibs=None, review_cfg={}):
         >>> review_edges = get_review_edges(cm_list, review_cfg=review_cfg, ibs=ibs)
         >>> print(review_edges)
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     from wbia.algo.hots import chip_match
     automatch_kw = REVIEW_CFG_DEFAULTS.copy()
     automatch_kw = ut.update_existing(automatch_kw, review_cfg)
@@ -633,7 +633,7 @@ def make_ensure_match_img_nosql_func(qreq_, cm, daid):
     import cv2
     import io
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     import matplotlib as mpl
 
     if cm.__class__.__name__ == 'PairwiseMatch':

--- a/wbia/gui/inspect_gui.py
+++ b/wbia/gui/inspect_gui.py
@@ -860,8 +860,8 @@ def make_vsone_tuner(ibs, edge=None, qreq_=None, autoupdate=True,
         >>> gt.qtapp_loop(qwin=self, freq=10)
 
     """
-    from vtool_ibeis import inspect_matches
-    import vtool_ibeis as vt
+    from vtool import inspect_matches
+    import vtool as vt
 
     if cfgdict is not None:
         assert qreq_ is None, 'specify only one cfg or qreq_'

--- a/wbia/guitool/api_item_model.py
+++ b/wbia/guitool/api_item_model.py
@@ -370,7 +370,7 @@ class APIItemModel(API_MODEL_BASE):
                         values[np.isnan(values)] = -np.inf
                     elif type_ is str:
                         values = ut.replace_nones(values, '')
-                    import vtool_ibeis as vt
+                    import vtool as vt
                     sortx = vt.argsort_records([values, id_list], reverse=reverse)
                     # </NUMPY MULTIARRAY SORT>
                     nodes = ut.take(children, sortx)

--- a/wbia/guitool/api_thumb_delegate.py
+++ b/wbia/guitool/api_thumb_delegate.py
@@ -20,7 +20,7 @@ MAX_NUM_THUMB_THREADS = 1
 
 
 def read_thumb_size(thumb_path):
-    import vtool_ibeis as vt
+    import vtool as vt
     if VERBOSE_THUMB:
         print('[ThumbDelegate] Reading thumb size')
     # npimg = vt.imread(thumb_path, delete_if_corrupted=True)
@@ -436,7 +436,7 @@ def get_thread_thumb_info(bbox_list, theta_list, thumbsize, img_size):
         ((128, 64), [[[21, 11], [107, 11], [107, 53], [21, 53], [21, 11]]])
 
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     theta_list = [theta_list] if not ut.is_listlike(theta_list) else theta_list
     max_dsize = (thumbsize, thumbsize)
     dsize, sx, sy = vt.resized_clamped_thumb_dims(img_size, max_dsize)
@@ -466,8 +466,8 @@ def make_thread_thumb(img_path, dsize, new_verts_list, interest_list):
         >>> pt.imshow(thumb)
         >>> pt.show_if_requested()
     """
-    import vtool_ibeis as vt
-    from vtool_ibeis import geometry
+    import vtool as vt
+    from vtool import geometry
     orange_bgr = (0, 128, 255)
     blue_bgr = (255, 128, 0)
     # imread causes a MEMORY LEAK most likely!
@@ -560,7 +560,7 @@ class ThumbnailCreationThread(RUNNABLE_BASE):
 
     def _run(thread):
         """ Compute thumbnail in a different thread """
-        import vtool_ibeis as vt
+        import vtool as vt
         #time.sleep(.005)  # Wait a in case the user is just scrolling
         if thread.thumb_would_not_be_visible():
             return
@@ -629,7 +629,7 @@ def simple_thumbnail_widget():
     guitool_test_thumbdir = ut.ensure_app_resource_dir('guitool', 'thumbs')
     ut.delete(guitool_test_thumbdir)
     ut.ensuredir(guitool_test_thumbdir)
-    import vtool_ibeis as vt
+    import vtool as vt
     from os.path import join
 
     #imgname_list = sorted(ut.TESTIMG_URL_DICT.keys())
@@ -640,7 +640,7 @@ def simple_thumbnail_widget():
     # num_imgs = list(range(500))
 
     def thread_func(would_be, id_):
-        from vtool_ibeis.fontdemo import get_text_test_img
+        from vtool.fontdemo import get_text_test_img
         get_text_test_img(id_)
 
     def thumb_getter(id_, thumbsize=128):

--- a/wbia/init/filter_annots.py
+++ b/wbia/init/filter_annots.py
@@ -1608,7 +1608,7 @@ def get_reference_preference_order(ibs, gt_ref_grouped_aids,
     r"""
     Orders preference for sampling based on some metric
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     grouped_reference_unixtimes = ibs.unflat_map(
         prop_getter, gt_ref_grouped_aids)
     grouped_available_gt_unixtimes = ibs.unflat_map(
@@ -1907,7 +1907,7 @@ def sample_annots(ibs, avail_aids, aidcfg, prefix='', verbose=VERB_TESTDATA):
         >>> daids = sample_annots_wrt_ref(ibs, initial_aids, dcfg, qaids, prefix, verbose)
         >>> ibs.print_annotconfig_stats(qaids, daids, enc_per_name=True, per_enc=True)
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     from wbia.expt import annotation_configs
 
     def get_cfg(key):

--- a/wbia/init/sysres.py
+++ b/wbia/init/sysres.py
@@ -624,7 +624,7 @@ def ensure_pz_mtest_batchworkflow_test():
                 imageset_aids_list[imageset_idx].extend(chunk)
                 imageset_idx = (imageset_idx + 1) % len(imageset_aids_list)
 
-            #import vtool_ibeis as vt
+            #import vtool as vt
             #import networkx as netx
             #nodes = list(range(len(aids)))
             #edges_pairs = vt.pdist_argsort(hourdiffs)

--- a/wbia/other/dbinfo.py
+++ b/wbia/other/dbinfo.py
@@ -628,7 +628,7 @@ def hackshow_names(ibs, aid_list, fnum=None):
         >>> ut.show_if_requested()
     """
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     grouped_aids, nid_list = ibs.group_annots_by_name(aid_list)
     grouped_aids = [aids for aids in grouped_aids if len(aids) > 1]
     unixtimes_list = ibs.unflat_map(ibs.get_annot_image_unixtimes_asfloat, grouped_aids)
@@ -702,7 +702,7 @@ def show_image_time_distributions(ibs, gid_list):
 def show_time_distributions(ibs, unixtime_list):
     r"""
     """
-    #import vtool_ibeis as vt
+    #import vtool as vt
     import wbia.plottool as pt
     unixtime_list = np.array(unixtime_list)
     num_nan = np.isnan(unixtime_list).sum()
@@ -742,7 +742,7 @@ def show_time_distributions(ibs, unixtime_list):
         icon = ibs.get_database_icon()
         if False and icon is not None:
             #import matplotlib as mpl
-            #import vtool_ibeis as vt
+            #import vtool as vt
             ax = pt.gca()
             # Overlay a species icon
             # http://matplotlib.org/examples/pylab_examples/demo_annotation_box.html

--- a/wbia/other/detectcore.py
+++ b/wbia/other/detectcore.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from six.moves import zip
 from os.path import exists, expanduser, join, abspath, basename
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import utool as ut
 import cv2
 import wbia.constants as const

--- a/wbia/other/detectfuncs.py
+++ b/wbia/other/detectfuncs.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from six.moves import zip, range
 from os.path import expanduser, join, abspath
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import utool as ut
 import cv2
 from wbia.control import controller_inject

--- a/wbia/other/ibsfuncs.py
+++ b/wbia/other/ibsfuncs.py
@@ -20,7 +20,7 @@ import re
 from six.moves import zip, range, map, reduce
 from os.path import split, join, exists
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import utool as ut
 import ubelt as ub
 from utool._internal.meta_util_six import get_funcname, set_funcname
@@ -937,7 +937,7 @@ def check_annot_size(ibs):
 
 def check_exif_data(ibs, gid_list):
     """ TODO CALL SCRIPT """
-    import vtool_ibeis.exif as exif
+    import vtool.exif as exif
     from PIL import Image  # NOQA
     gpath_list = ibs.get_image_paths(gid_list)
     exif_dict_list = []
@@ -1112,7 +1112,7 @@ def fix_exif_data(ibs, gid_list):
         >>> result = fix_exif_data(ibs, gid_list)
         >>> print(result)
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     from PIL import Image  # NOQA
     gpath_list = ibs.get_image_paths(gid_list)
 
@@ -2670,7 +2670,7 @@ def get_extended_viewpoints(base_yaw_text, towards='front', num1=0,
         >>> print(result)
         extended_yaws_list = [['frontleft'], ['frontright'], ['backleft'], ['frontleft']]
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     # DEPRICATE?
     ori1 = const.VIEWTEXT_TO_YAW_RADIANS[base_yaw_text]
     ori2 = const.VIEWTEXT_TO_YAW_RADIANS[towards]
@@ -2890,7 +2890,7 @@ def get_yaw_viewtexts(yaw_list):
         ['right', 'front', 'frontright', 'left', 'left', 'backright', 'back', 'right', 'backleft', 'frontright', 'frontright', None]
 
     """
-    #import vtool_ibeis as vt
+    #import vtool as vt
     import numpy as np
     stdlblyaw_list = list(const.VIEWTEXT_TO_YAW_RADIANS.items())
     stdlbl_list = ut.get_list_column(stdlblyaw_list, 0)
@@ -4327,7 +4327,7 @@ def filter_annots_using_minimum_timedelta(ibs, aid_list, min_timedelta):
         >>> wbia.other.dbinfo.hackshow_names(ibs, filtered_aids)
         >>> ut.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     #min_timedelta = 60 * 60 * 24
     #min_timedelta = 60 * 10
     grouped_aids = ibs.group_annots_by_name(aid_list)[0]
@@ -6780,7 +6780,7 @@ def overwrite_ggr_unixtimes_from_gps(ibs, gmt_offset=3.0, *args, **kwargs):
 
 
 def overwrite_unixtimes_from_gps_worker(path):
-    from vtool_ibeis.exif import parse_exif_unixtime_gps
+    from vtool.exif import parse_exif_unixtime_gps
     unixtime_gps = parse_exif_unixtime_gps(path)
     return unixtime_gps
 

--- a/wbia/plottool/_cv2_impaint.py
+++ b/wbia/plottool/_cv2_impaint.py
@@ -14,7 +14,7 @@ def impaint_mask(img, label_colors=None, init_mask=None, init_label=None):
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.interact_impaint import *  # NOQA
         >>> import utool as ut
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> img_fpath = ut.grab_test_imgpath('lena.png')
         >>> img = vt.imread(img_fpath)
         >>> label_colors = [255, 200, 100, 0]
@@ -129,7 +129,7 @@ def impaint_mask(img, label_colors=None, init_mask=None, init_label=None):
 
 def cached_impaint(bgr_img, cached_mask_fpath=None, label_colors=None,
                    init_mask=None, aug=False, refine=False):
-    import vtool_ibeis as vt
+    import vtool as vt
     if cached_mask_fpath is None:
         cached_mask_fpath = 'image_' + ut.hashstr_arr(bgr_img) + '.png'
     if aug:

--- a/wbia/plottool/color_funcs.py
+++ b/wbia/plottool/color_funcs.py
@@ -221,7 +221,7 @@ def testshow_colors(rgb_list, gray=ut.get_argflag('--gray')):
         >>> pt.show_if_requested()
     """
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     block = np.zeros((5, 5, 3))
     block_list = [block + color[0:3] for color in rgb_list]
     #print(ut.repr2(block_list))

--- a/wbia/plottool/draw_func2.py
+++ b/wbia/plottool/draw_func2.py
@@ -307,7 +307,7 @@ def overlay_icon(icon, coords=(0, 0), coord_type='axes', bbox_alignment=(0, 0),
         >>> pt.show_if_requested()
     """
     #from mpl_toolkits.axes_grid.anchored_artists import AnchoredAuxTransformBox
-    import vtool_ibeis as vt
+    import vtool as vt
     ax = gca()
     if isinstance(icon, six.string_types):
         # hack because icon is probably a url
@@ -775,7 +775,7 @@ def show_if_requested(N=1):
         #import sys
         from os.path import basename, splitext, join, dirname
         import wbia.plottool as pt
-        import vtool_ibeis as vt
+        import vtool as vt
 
         # HACK
         arg_dict = {
@@ -1385,10 +1385,10 @@ def rotate_plot(theta=TAU / 8, ax=None):
         >>> print(result)
         >>> show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     if ax is None:
         ax = gca()
-    #import vtool_ibeis as vt
+    #import vtool as vt
     xy, width, height = get_axis_xy_width_height(ax)
     bbox = [xy[0], xy[1], width, height]
     M = mpl.transforms.Affine2D(vt.rotation_around_bbox_mat3x3(theta, bbox))
@@ -2075,7 +2075,7 @@ def plot_sift_signature(sift, title='', fnum=None, pnum=None):
     Example:
         >>> # ENABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> sift = vt.demodata.testdata_dummy_sift(1, np.random.RandomState(0))[0]
         >>> title = 'test sift histogram'
         >>> fnum = None
@@ -2127,7 +2127,7 @@ def plot_descriptor_signature(vec, title='', fnum=None, pnum=None):
     Example:
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> vec = ((np.random.RandomState(0).rand(258) - .2) * 4)
         >>> title = 'test sift histogram'
         >>> fnum = None
@@ -2441,7 +2441,7 @@ def scores_to_color(score_list, cmap_='hot', logscale=False, reverse_cmap=False,
         >>> # score_list = np.linspace(0, 1, 100)
         >>> cmap_ = 'plasma'
         >>> colors = pt.scores_to_color(score_list, cmap_)
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> imgRGB = vt.atleast_nd(np.array(colors)[:, 0:3], 3, tofront=True)
         >>> imgRGB = imgRGB.astype(np.float32)
         >>> imgBGR = vt.convert_colorspace(imgRGB, 'BGR', 'RGB')
@@ -2954,7 +2954,7 @@ def draw_lines2(kpts1, kpts2, fm=None, fs=None, kpts2_offset=(0, 0),
                 color_list=None, scale_factor=1, lw=1.4, line_alpha=.35,
                 H1=None, H2=None, scale_factor1=None, scale_factor2=None,
                 ax=None, **kwargs):
-    import vtool_ibeis as vt
+    import vtool as vt
     if scale_factor1 is None:
         scale_factor1 = 1.0, 1.0
     if scale_factor2 is None:
@@ -3120,13 +3120,13 @@ def show_kpts(kpts, fnum=None, pnum=None, **kwargs):
     Example:
         >>> # ENABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> kpts = vt.demodata.get_dummy_kpts()
         >>> result = show_kpts(kpts)
         >>> import wbia.plottool as pt
         >>> pt.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia.plottool as pt
     pt.figure(doclf=True, fnum=pt.ensure_fnum(fnum), pnum=pnum)
     pt.draw_kpts2(kpts, **kwargs)
@@ -3267,7 +3267,7 @@ def draw_keypoint_gradient_orientations(rchip, kpt, sift=None, mode='vec',
     it with respect to the current mode.
 
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     wpatch, wkp  = vt.get_warped_patch(rchip, kpt, gray=True)
     try:
         gradx, grady = vt.patch_gradient(wpatch)
@@ -3312,7 +3312,7 @@ def draw_keypoint_patch(rchip, kp, sift=None, warped=False, patch_dict={}, **kwa
     Example:
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> rchip = vt.imread(ut.grab_test_imgpath('lena.png'))
         >>> kp = [100, 100, 20, 0, 20, 0]
         >>> sift = None
@@ -3324,7 +3324,7 @@ def draw_keypoint_patch(rchip, kp, sift=None, warped=False, patch_dict={}, **kwa
         >>> import wbia.plottool as pt
         >>> pt.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     #print('--------------------')
     kpts = np.array([kp])
     if warped:
@@ -3395,7 +3395,7 @@ def imshow(img, fnum=None, title=None, figtitle=None, pnum=None,
     Example:
         >>> # ENABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> img_fpath = ut.grab_test_imgpath('carl.jpg')
         >>> img = vt.imread(img_fpath)
         >>> (fig, ax) = imshow(img)
@@ -3422,7 +3422,7 @@ def imshow(img, fnum=None, title=None, figtitle=None, pnum=None,
         # Allow for path to image to be specified
         img_fpath = img
         ut.assertpath(img_fpath)
-        import vtool_ibeis as vt
+        import vtool as vt
         img = vt.imread(img_fpath)
     #darken = .4
     if darken is not None:
@@ -3546,7 +3546,7 @@ def draw_vector_field(gx, gy, fnum=None, pnum=None, title=None, invert=True,
         >>> # DISABLE_DOCTEST
         >>> import wbia.plottool as pt
         >>> import utool as ut
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> patch = vt.testdata_patch()
         >>> gx, gy = vt.patch_gradient(patch, gaussian_weighted=False)
         >>> stride = ut.get_argval('--stride', default=1)
@@ -3648,7 +3648,7 @@ def show_chipmatch2(rchip1, rchip2, kpts1=None, kpts2=None, fm=None, fs=None,
         >>> # ENABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
         >>> import wbia.plottool as pt
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> rchip1 = vt.imread(ut.grab_test_imgpath('easy1.png'))
         >>> rchip2 = vt.imread(ut.grab_test_imgpath('easy2.png'))
         >>> kpts1 = np.array([
@@ -3679,7 +3679,7 @@ def show_chipmatch2(rchip1, rchip2, kpts1=None, kpts2=None, fm=None, fs=None,
         >>> result = show_chipmatch2(rchip1, rchip2, kpts1, kpts2, **kwargs)
         >>> pt.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     if ut.VERBOSE:
         print('[df2] show_chipmatch2() fnum=%r, pnum=%r, ax=%r' % (fnum, pnum, ax))
     wh1 = vt.get_size(rchip1)
@@ -3690,7 +3690,7 @@ def show_chipmatch2(rchip1, rchip2, kpts1=None, kpts2=None, fm=None, fs=None,
         dsize2 = wh1
 
     if heatmask:
-        from vtool_ibeis.coverage_kpts import make_kpts_heatmask
+        from vtool.coverage_kpts import make_kpts_heatmask
         if not kwargs.get('all_kpts', False) and fm is not None:
             kpts1_m = kpts1[fm.T[0]]
             kpts2_m = kpts2[fm.T[1]]
@@ -3943,7 +3943,7 @@ def color_orimag(gori, gmag=None, gmag_is_01=None, encoding='rgb', p=.5):
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
         >>> import wbia.plottool as pt
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> # build test data
         >>> gori = np.array([[ 0.        ,  0.        ,  3.14159265,  3.14159265,  0.        ],
         ...                  [ 1.57079633,  3.92250052,  1.81294053,  3.29001537,  1.57079633],
@@ -4227,7 +4227,7 @@ def width_from(num, pad=.05, start=0, stop=1):
 
 
 #+-----
-# From vtool_ibeis.patch
+# From vtool.patch
 def param_plot_iterator(param_list, fnum=None, projection=None):
     from wbia.plottool import plot_helpers
     nRows, nCols = plot_helpers.get_square_row_cols(len(param_list), fix=True)
@@ -4262,7 +4262,7 @@ def plot_surface3d(xgrid, ygrid, zdata, xlabel=None, ylabel=None, zlabel=None,
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.draw_func2 import *  # NOQA
         >>> import wbia.plottool as pt
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> shape=(19, 19)
         >>> sigma1, sigma2 = 2.0, 1.0
         >>> ybasis = np.arange(shape[0])

--- a/wbia/plottool/draw_sv.py
+++ b/wbia/plottool/draw_sv.py
@@ -3,7 +3,7 @@ import utool as ut
 import numpy as np
 from . import draw_func2 as df2
 from wbia.plottool import custom_constants
-#from vtool_ibeis import keypoint as ktool
+#from vtool import keypoint as ktool
 #(print, print_, printDBG, rrr, profile) = ut.inject(__name__, '[viz_sv]', DEBUG=False)
 ut.noinject(__name__, '[viz_sv]')
 
@@ -12,7 +12,7 @@ def get_blended_chip(chip1, chip2, M):
     """
     warps chip1 into chip2 space
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     wh2 = vt.get_size(chip2)
     chip1_Mt = vt.warpHomog(chip1, M, wh2)
     chip2_blendM = vt.blend_images(chip1_Mt, chip2)
@@ -26,10 +26,10 @@ def show_sv(chip1, chip2, kpts1, kpts2, fm, homog_tup=None, aff_tup=None,
     """ Visualizes spatial verification
 
     CommandLine:
-        python -m vtool_ibeis.spatial_verification --test-spatially_verify_kpts --show
+        python -m vtool.spatial_verification --test-spatially_verify_kpts --show
 
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     #import wbia.plottool as pt
     # GEt Matching chips
     kpts1_m = kpts1[fm.T[0]]
@@ -165,7 +165,7 @@ def show_sv_simple(chip1, chip2, kpts1, kpts2, fm, inliers, mx=None, fnum=1, ver
     Example:
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.draw_sv import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> kpts1, kpts2, fm, aff_inliers, chip1, chip2, xy_thresh_sqrd = vt.testdata_matching_affine_inliers()
         >>> inliers = aff_inliers
         >>> mx = None
@@ -177,7 +177,7 @@ def show_sv_simple(chip1, chip2, kpts1, kpts2, fm, inliers, mx=None, fnum=1, ver
         >>> pt.show_if_requested()
     """
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     colors = pt.distinct_colors(2, brightness=.95)
     color1, color2 = colors[0:2]
     # Begin the drawing

--- a/wbia/plottool/interact_annotations.py
+++ b/wbia/plottool/interact_annotations.py
@@ -32,7 +32,7 @@ import six
 import re
 import numpy as np
 try:
-    import vtool_ibeis as vt
+    import vtool as vt
 except ImportError:
     pass
 import utool as ut
@@ -1204,7 +1204,7 @@ def rotate_points_around(points, theta, ax, ay):
     References:
         http://www.euclideanspace.com/maths/geometry/affine/aroundPoint/matrix2d/
     """
-    # TODO: Can use vtool_ibeis for this
+    # TODO: Can use vtool for this
     sin, cos, array = np.sin, np.cos, np.array
     augpts = array([array((x, y, 1)) for (x, y) in points])
     ct = cos(theta)

--- a/wbia/plottool/interact_impaint.py
+++ b/wbia/plottool/interact_impaint.py
@@ -14,7 +14,7 @@ import utool as ut
 import matplotlib.pyplot as plt
 import numpy as np
 try:
-    import vtool_ibeis as vt
+    import vtool as vt
 except ImportError:
     pass
 from wbia.plottool import abstract_interaction

--- a/wbia/plottool/interact_keypoints.py
+++ b/wbia/plottool/interact_keypoints.py
@@ -24,7 +24,7 @@ class KeypointInteraction(abstract_interaction.AbstractInteraction):
         >>> import wbia.plottool as pt
         >>> import utool as ut
         >>> import pyhesaff
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> kpts, vecs, imgBGR = pt.viz_keypoints.testdata_kpts()
         >>> ut.quit_if_noshow()
         >>> #pt.interact_keypoints.ishow_keypoints(imgBGR, kpts, vecs, ori=True, ell_alpha=.4, color='distinct')
@@ -79,7 +79,7 @@ class KeypointInteraction(abstract_interaction.AbstractInteraction):
             else:
                 print('...nearest')
                 x, y = event.xdata, event.ydata
-                import vtool_ibeis as vt
+                import vtool as vt
                 fx = vt.nearest_point(x, y, kpts)[0]
                 self._select_ith_kpt(fx)
         elif viztype == 'warped':
@@ -113,7 +113,7 @@ def ishow_keypoints(chip, kpts, desc, fnum=0, figtitle=None, nodraw=False, **kwa
         >>> import wbia.plottool as pt
         >>> import utool as ut
         >>> import pyhesaff
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> kpts, vecs, imgBGR = pt.viz_keypoints.testdata_kpts()
         >>> ut.quit_if_noshow()
         >>> #pt.interact_keypoints.ishow_keypoints(imgBGR, kpts, vecs, ori=True, ell_alpha=.4, color='distinct')
@@ -121,7 +121,7 @@ def ishow_keypoints(chip, kpts, desc, fnum=0, figtitle=None, nodraw=False, **kwa
         >>> pt.show_if_requested()
     """
     if isinstance(chip, six.string_types):
-        import vtool_ibeis as vt
+        import vtool as vt
         chip = vt.imread(chip)
     fig = ih.begin_interaction('keypoint', fnum)
     annote_ptr = [1]
@@ -167,7 +167,7 @@ def ishow_keypoints(chip, kpts, desc, fnum=0, figtitle=None, nodraw=False, **kwa
                 else:
                     print('...nearest')
                     x, y = event.xdata, event.ydata
-                    import vtool_ibeis as vt
+                    import vtool as vt
                     fx = vt.nearest_point(x, y, kpts)[0]
                     _select_ith_kpt(fx)
             elif viztype == 'warped':

--- a/wbia/plottool/interact_matches.py
+++ b/wbia/plottool/interact_matches.py
@@ -258,7 +258,7 @@ class MatchInteraction2(BASE_CLASS):
                 kpts1_m = self.kpts1[self.fm[:, 0]]
                 kpts2_m = self.kpts2[self.fm[:, 1]]
                 x2, y2, w2, h2 = self.xywh2
-                import vtool_ibeis as vt
+                import vtool as vt
                 _mx1, _dist1 = vt.nearest_point(x, y, kpts1_m)
                 _mx2, _dist2 = vt.nearest_point(x - x2, y - y2, kpts2_m)
                 mx = _mx1 if _dist1 < _dist2 else _mx2

--- a/wbia/plottool/interact_multi_image.py
+++ b/wbia/plottool/interact_multi_image.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt  # NOQA
 import matplotlib as mpl  # NOQA
 import six
 try:
-    import vtool_ibeis as vt
+    import vtool as vt
 except ImportError:
     pass
 #import utool

--- a/wbia/plottool/mpl_keypoint.py
+++ b/wbia/plottool/mpl_keypoint.py
@@ -63,7 +63,7 @@ def draw_keypoints(ax, kpts_, scale_factor=1.0, offset=(0.0, 0.0), rotation=0.0,
         >>> from wbia.plottool.mpl_keypoint import *  # NOQA
         >>> from wbia.plottool.mpl_keypoint import _draw_patches, _draw_pts  # NOQA
         >>> import wbia.plottool as pt
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> imgBGR = vt.get_star_patch(jitter=True)
         >>> H = np.array([[1, 0, 0], [.5, 2, 0], [0, 0, 1]])
         >>> H = np.array([[.8, 0, 0], [0, .8, 0], [0, 0, 1]])
@@ -93,7 +93,7 @@ def draw_keypoints(ax, kpts_, scale_factor=1.0, offset=(0.0, 0.0), rotation=0.0,
         >>> pt.iup()
         >>> pt.show_if_requested()
     """
-    import vtool_ibeis.keypoint as ktool
+    import vtool.keypoint as ktool
     if kpts_.shape[1] == 2:
         # pad out structure if only xy given
         kpts = np.zeros((len(kpts_), 6))
@@ -156,7 +156,7 @@ def draw_keypoints(ax, kpts_, scale_factor=1.0, offset=(0.0, 0.0), rotation=0.0,
             _xs, _ys = ktool.get_xys(kpts)
             if H is not None:
                 # adjust for homogrpahy
-                import vtool_ibeis as vt
+                import vtool as vt
                 _xs, _ys = vt.transform_points_with_homography(H, np.vstack((_xs, _ys)))
 
             pts_patches = _draw_pts(ax, _xs, _ys, pts_size, pts_color, pts_alpha)
@@ -209,7 +209,7 @@ class HomographyTransform(mpl.transforms.Transform):
         """
         The input and output are Nx2 numpy arrays.
         """
-        import vtool_ibeis as vt
+        import vtool as vt
         _xys = input_xy.T
         xy_t = vt.transform_points_with_homography(self.H, _xys)
         output_xy = xy_t.T
@@ -231,7 +231,7 @@ def get_invVR_aff2Ds(kpts, H=None):
 
     Example:
         >>> # Test CV2 ellipse vs mine using MSER
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> import cv2
         >>> import wbia.plottool as pt
         >>> img_fpath = ut.grab_test_imgpath(ut.get_argval('--fname', default='zebra.png'))
@@ -264,7 +264,7 @@ def get_invVR_aff2Ds(kpts, H=None):
         >>> # we start out with a unit circle not a half circle
         >>> pt.draw_keypoints(pt.gca(), kpts, pts=True, ori=True, eig=True, rect=True)
     """
-    import vtool_ibeis.keypoint as ktool
+    import vtool.keypoint as ktool
     #invVR_mats = ktool.get_invV_mats(kpts, with_trans=True, with_ori=True)
     invVR_mats = ktool.get_invVR_mats3x3(kpts)
     if H is None:
@@ -314,7 +314,7 @@ def eigenvector_actors(invVR_aff2Ds):
 
 def orientation_actors(kpts, H=None):
     """ creates orientation actors w.r.t. the gravity vector """
-    import vtool_ibeis.keypoint as ktool
+    import vtool.keypoint as ktool
     try:
         # Get xy diretion of the keypoint orientations
         _xs, _ys = ktool.get_xys(kpts)
@@ -332,7 +332,7 @@ def orientation_actors(kpts, H=None):
 
         #if H is not None:
         #    # adjust for homogrpahy
-        #    import vtool_ibeis as vt
+        #    import vtool as vt
         #    _xs, _ys = vt.transform_points_with_homography(H, np.vstack((_xs, _ys)))
         #    _dxs, _dys = vt.transform_points_with_homography(H, np.vstack((_dxs, _dys)))
 

--- a/wbia/plottool/nx_helpers.py
+++ b/wbia/plottool/nx_helpers.py
@@ -88,7 +88,7 @@ def show_nx(graph, with_labels=True, fnum=None, pnum=None, layout='agraph',
         python -m wbia.plottool.nx_helpers show_nx --show
         python -m dtool --tf DependencyCache.make_graph --show
         python -m wbia.scripts.specialdraw double_depcache_graph --show --testmode
-        python -m vtool_ibeis.clustering2 unsupervised_multicut_labeling --show
+        python -m vtool.clustering2 unsupervised_multicut_labeling --show
 
 
     Example:
@@ -204,7 +204,7 @@ def netx_draw_images_at_positions(img_list, pos_list, size_list, color_list,
         http://matplotlib.org/api/text_api.html
         http://matplotlib.org/api/offsetbox_api.html
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia.plottool as pt
     # Ensure all images have been read
     img_list_ = [vt.convert_colorspace(vt.imread(img), 'RGB')
@@ -1095,7 +1095,7 @@ def _get_node_size(graph, node, node_size):
     else:
         if 'image' in nattrs:
             img_fpath = nattrs['image']
-            import vtool_ibeis as vt
+            import vtool as vt
             width, height = vt.image.open_image_size(img_fpath)
         else:
             height = width = 1100 / 50 * scale
@@ -1203,7 +1203,7 @@ def draw_network2(graph, layout_info, ax, as_directed=None, hacknoedge=False,
             else:
                 bbox = list(xy_bl) + [width, height]
                 if isdiag:
-                    import vtool_ibeis as vt
+                    import vtool as vt
                     center_xy  = vt.bbox_center(bbox)
                     _xy =  np.array(center_xy)
                     newverts_ = [
@@ -1384,7 +1384,7 @@ def draw_network2(graph, layout_info, ax, as_directed=None, hacknoedge=False,
                 width = .5
                 lw = 1.0
                 try:
-                    import vtool_ibeis as vt
+                    import vtool as vt
                     # Compute arrow width using estimated graph size
                     if node_size is not None and node_pos is not None:
                         xys = np.array(ut.take(node_pos, node_pos.keys())).T

--- a/wbia/plottool/other.py
+++ b/wbia/plottool/other.py
@@ -4,7 +4,7 @@ from six.moves import zip
 import numpy as np
 import cv2
 import matplotlib.pyplot as plt
-import vtool_ibeis.histogram as htool
+import vtool.histogram as htool
 import utool as ut
 ut.noinject(__name__, '[pt.other]')
 

--- a/wbia/plottool/plot_helpers.py
+++ b/wbia/plottool/plot_helpers.py
@@ -172,7 +172,7 @@ ensureqt = qt4ensure
 
 
 def kp_info(kp):
-    import vtool_ibeis.keypoint as ktool
+    import vtool.keypoint as ktool
     kpts = np.array([kp])
     xy_str    = ktool.get_xy_strs(kpts)[0]
     shape_str = ktool.get_shape_strs(kpts)[0]

--- a/wbia/plottool/plots.py
+++ b/wbia/plottool/plots.py
@@ -637,7 +637,7 @@ def plot_multiple_scores(known_nd_data, known_target_points, nd_labels,
 
     if report_max:
         # TODO: multiple max poses
-        import vtool_ibeis as vt
+        import vtool as vt
         maxpos_list = ydata_list.argmax(axis=1)
         max_nd0_list = nd_basis[0].take(maxpos_list)
         max_score_list = vt.ziptake(ydata_list, maxpos_list)
@@ -767,7 +767,7 @@ def draw_hist_subbin_maxima(hist, centers=None, bin_colors=None,
         >>> pt.show_if_requested()
     """
     # Find maxima
-    import vtool_ibeis as vt
+    import vtool as vt
     maxima_x, maxima_y, argmaxima = vt.hist_argmaxima(hist, centers, maxima_thresh)
     argmaxima = np.array(ut.ensure_iterable(argmaxima))
     maxima_y = np.array(ut.ensure_iterable(maxima_y))
@@ -846,7 +846,7 @@ def draw_subextrema(ydata, xdata=None, op='max', bin_colors=None,
     Example:
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.plots import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> import wbia.plottool as pt
         >>> ydata = np.array([    6.73, 8.69, 0.00, 0.00, 34.62, 29.16, 0.01, 0.00, 6.73, 8.69])
         >>> xdata = np.array([-0.39, 0.39, 1.18, 1.96,  2.75,  3.53, 4.32, 5.11, 5.89, 6.68])
@@ -861,7 +861,7 @@ def draw_subextrema(ydata, xdata=None, op='max', bin_colors=None,
         >>> pt.show_if_requested()
     """
     # Find maxima
-    import vtool_ibeis as vt
+    import vtool as vt
     # Hack into the source code
     locals_ = ut.exec_func_src2(vt.argsubextrema2)
 
@@ -2244,7 +2244,7 @@ def draw_histogram(bin_labels, bin_values, xlabel='',  ylabel='Freq',
 
 
 def draw_time_distribution(unixtime_list, bw=None):
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia.plottool as pt
     if len(unixtime_list) > 0:
         from sklearn.neighbors.kde import KernelDensity

--- a/wbia/plottool/viz_featrow.py
+++ b/wbia/plottool/viz_featrow.py
@@ -84,7 +84,7 @@ def draw_feat_row(chip, fx, kp, sift, fnum, nRows, nCols=None, px=None, prevsift
         >>> pt.show_if_requested()
     """
     import numpy as np
-    import vtool_ibeis as vt
+    import vtool as vt
     # should not need ncols here
 
     if nCols is not None:

--- a/wbia/plottool/viz_keypoints.py
+++ b/wbia/plottool/viz_keypoints.py
@@ -9,7 +9,7 @@ utool.noinject(__name__, '[viz_keypoints]')
 
 def testdata_kpts():
     import utool as ut
-    import vtool_ibeis as vt
+    import vtool as vt
     import pyhesaff
     img_fpath = ut.grab_test_imgpath(ut.get_argval('--fname', default='star.png'))
     kwargs = ut.parse_dict_from_argv(pyhesaff.get_hesaff_default_params())
@@ -36,7 +36,7 @@ def show_keypoints(chip, kpts, fnum=0, pnum=None, **kwargs):
     Example:
         >>> # DISABLE_DOCTEST
         >>> from wbia.plottool.viz_keypoints import *  # NOQA
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> kpts, vecs, chip = testdata_kpts()
         >>> fnum = 0
         >>> pnum = None
@@ -83,7 +83,7 @@ def _annotate_kpts(kpts_, sel_fx=None, **kwargs):
         color = df2.distinct_colors(len(kpts_))  # , randomize=True)
     elif color == 'scale':
         # hack for distinct colors
-        import vtool_ibeis as vt
+        import vtool as vt
         #color = df2.scores_to_color(vt.get_scales(kpts_), cmap_='inferno', score_range=(0, 50))
         color = df2.scores_to_color(vt.get_scales(kpts_), cmap_='viridis', score_range=(5, 30), cmap_range=None)
         #df2.distinct_colors(len(kpts_))  # , randomize=True)

--- a/wbia/scripts/_neighbor_experiment.py
+++ b/wbia/scripts/_neighbor_experiment.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 import utool as ut
-from vtool_ibeis._pyflann_backend import pyflann as pyflann
+from vtool._pyflann_backend import pyflann as pyflann
 from os.path import basename, exists  # NOQA
 from six.moves import range
 from wbia.algo.hots import neighbor_index_cache
@@ -335,7 +335,7 @@ def subindexer_time_experiment():
     """
     import wbia
     import utool as ut
-    from vtool_ibeis._pyflann_backend import pyflann as pyflann
+    from vtool._pyflann_backend import pyflann as pyflann
     import wbia.plottool as pt
     ibs = wbia.opendb(db='PZ_Master0')
     daid_list = ibs.get_valid_aids()
@@ -614,11 +614,11 @@ def trytest_multiple_add_removes():
     idx2_vec_masked = nnindexer.idx2_vec
     idx2_vec_compressed = nnindexer.get_indexed_vecs()
 
-    from vtool_ibeis._pyflann_backend import pyflann as pyflann
+    from vtool._pyflann_backend import pyflann as pyflann
     flann1 = pyflann.FLANN()
     flann1.load_index('test.flann', idx2_vec_masked)
 
-    from vtool_ibeis._pyflann_backend import pyflann as pyflann
+    from vtool._pyflann_backend import pyflann as pyflann
     flann2 = pyflann.FLANN()
     flann2.load_index('test.flann', idx2_vec_compressed)
 
@@ -639,7 +639,7 @@ def pyflann_test_remove_add():
         >>> from wbia.algo.hots._neighbor_experiment import *  # NOQA
         >>> pyflann_test_remove_add()
     """
-    from vtool_ibeis._pyflann_backend import pyflann as pyflann
+    from vtool._pyflann_backend import pyflann as pyflann
     import numpy as np
     rng = np.random.RandomState(0)
 
@@ -684,7 +684,7 @@ def pyflann_test_remove_add2():
         >>> from wbia.algo.hots._neighbor_experiment import *  # NOQA
         >>> pyflann_test_remove_add2()
     """
-    from vtool_ibeis._pyflann_backend import pyflann as pyflann
+    from vtool._pyflann_backend import pyflann as pyflann
     import numpy as np
     rng = np.random.RandomState(0)
     vecs = (rng.rand(400, 128) * 255).astype(np.uint8)
@@ -757,7 +757,7 @@ def pyflann_remove_and_save():
         >>> from wbia.algo.hots._neighbor_experiment import *  # NOQA
         >>> pyflann_remove_and_save()
     """
-    from vtool_ibeis._pyflann_backend import pyflann as pyflann
+    from vtool._pyflann_backend import pyflann as pyflann
     import numpy as np
     rng = np.random.RandomState(0)
     vecs = (rng.rand(400, 128) * 255).astype(np.uint8)

--- a/wbia/scripts/classify_shark.py
+++ b/wbia/scripts/classify_shark.py
@@ -424,7 +424,7 @@ def get_shark_dataset(target_type='binary', data_type='chip'):
     try:
         dataset.load()
     except IOError:
-        import vtool_ibeis as vt
+        import vtool as vt
         dataset.ensure_dirs()
 
         if data_type == 'hog':
@@ -1125,7 +1125,7 @@ def shark_svm():
 
             c_xdata = np.array([t[0]['C'] for t in grid.grid_scores_])
             c_ydata = np.array([t[1] for t in grid.grid_scores_])
-            import vtool_ibeis as vt
+            import vtool as vt
             #maxima_x, maxima_y, argmaxima = vt.hist_argmaxima(c_ydata, c_xdata, maxima_thresh=None)
             submaxima_x, submaxima_y = vt.argsubmaxima(c_ydata, c_xdata)
             #pt.draw_hist_subbin_maxima(c_ydata, c_xdata, maxima_thresh=None, remove_endpoints=False)

--- a/wbia/scripts/fix_annotation_orientation_issue.py
+++ b/wbia/scripts/fix_annotation_orientation_issue.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 
 (print, rrr, profile) = ut.inject2(__name__)
@@ -23,7 +23,7 @@ def fix_annotation_orientation(ibs, min_percentage=0.95):
         >>> unfixable_gid_list = fix_annotation_orientation(ibs)
         >>> assert len(unfixable_gid_list) == 0
     """
-    from vtool_ibeis import exif
+    from vtool import exif
 
     def bbox_overlap(bbox1, bbox2):
         ax1 = bbox1[0]

--- a/wbia/scripts/getshark.py
+++ b/wbia/scripts/getshark.py
@@ -1345,7 +1345,7 @@ def download_missing_images(parsed, num=None):
 
 def postprocess_corrupted(parsed_dl):
     # Remove corrupted or ill-formatted images
-    import vtool_ibeis as vt
+    import vtool as vt
     print('Checking for corrupted images')
     gpaths = fpaths = parsed_dl['new_fpath']
     valid_flags = vt.filterflags_valid_images(fpaths, verbose=2)

--- a/wbia/scripts/getshark_old.py
+++ b/wbia/scripts/getshark_old.py
@@ -321,7 +321,7 @@ def get_injured_sharks():
 
     fpath = './GOPR1120.JPG'
 
-    import vtool_ibeis as vt
+    import vtool as vt
     for fpath in [fpath]:
         """
         http://scikit-image.org/docs/dev/auto_examples/plot_hog.html
@@ -601,7 +601,7 @@ def shark_misc():
     #if False:
     #    print('Removing small images')
     #    import numpy as np
-    #    import vtool_ibeis as vt
+    #    import vtool as vt
     #    imgsize_list = np.array([vt.open_image_size(gpath) for gpath in parsed['new_fpath']])
     #    sqrt_area_list = np.sqrt(np.prod(imgsize_list, axis=1))
     #    areq_flags_list = sqrt_area_list >= 750

--- a/wbia/scripts/labelShark.py
+++ b/wbia/scripts/labelShark.py
@@ -5,7 +5,7 @@ import utool as ut
 import wbia
 from wbia.scripts import classify_shark
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 
 modelStateLocation = "https://wildbookiarepository.azureedge.net/models/classifier.lenet.whale_shark.pkl"
 

--- a/wbia/scripts/postdoc.py
+++ b/wbia/scripts/postdoc.py
@@ -16,7 +16,7 @@ import itertools as it
 import matplotlib as mpl
 from os.path import basename, join, splitext, exists  # NOQA
 import wbia.constants as const
-import vtool_ibeis as vt
+import vtool as vt
 from wbia.algo.graph.state import POSTV, NEGTV, INCMP, UNREV, UNKWN  # NOQA
 (print, rrr, profile) = ut.inject2(__name__)
 
@@ -611,7 +611,7 @@ def draw_match_states():
             INCMP: list(infr.incmp_graph.edges())[0],
         }
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     for key, edge in chosen.items():
         match = infr._make_matches_from([edge], config={
             'match_config': {'ratio_thresh': .7}})[0]

--- a/wbia/scripts/specialdraw.py
+++ b/wbia/scripts/specialdraw.py
@@ -23,7 +23,7 @@ def multidb_montage():
     """
     import wbia
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     import numpy as np
     pt.ensureqt()
     dbnames = [
@@ -1422,7 +1422,7 @@ def scalespace():
     import numpy as np
     # import matplotlib.pyplot as plt
     import cv2
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia.plottool as pt
     pt.qt4ensure()
 

--- a/wbia/scripts/thesis.py
+++ b/wbia/scripts/thesis.py
@@ -12,7 +12,7 @@ import numpy as np
 from os.path import basename, join, splitext, exists  # NOQA
 import utool as ut
 import wbia.plottool as pt
-import vtool_ibeis as vt
+import vtool as vt
 import pathlib
 import matplotlib as mpl
 import random
@@ -3799,7 +3799,7 @@ class Sampler(object):
             return subenc
 
         def _only_comparable(qsubenc, avail_dencs):
-            from vtool_ibeis import _rhomb_dist
+            from vtool import _rhomb_dist
             qviews = set(ut.flatten(qsubenc.viewpoint_code))
             comparable_encs = []
             for denc in avail_dencs:

--- a/wbia/tag_funcs.py
+++ b/wbia/tag_funcs.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import six
 from six.moves import zip, map
 import numpy as np
-import vtool_ibeis as vt
+import vtool as vt
 import utool as ut
 from wbia.control import controller_inject
 print, rrr, profile = ut.inject2(__name__)

--- a/wbia/tests/assert_modules.py
+++ b/wbia/tests/assert_modules.py
@@ -169,7 +169,7 @@ reg_std_version_check('1.1.6', 'cachetools')
 
 @checkinfo(None)
 def pyflann_version():
-    from vtool_ibeis._pyflann_backend import pyflann as pyflann
+    from vtool._pyflann_backend import pyflann as pyflann
     if LIB_DEP:
         libdep = None
     else:
@@ -199,16 +199,16 @@ def pyrf_version():
 
 @checkinfo('1.0.1')
 def vtool_version():
-    import vtool_ibeis
+    import vtool
     libdep = None
     if LIB_DEP:
         libdep = None
     else:
         try:
-            libdep = ut.get_dynlib_dependencies(vtool_ibeis.sver_c_wrapper.lib_fname)
+            libdep = ut.get_dynlib_dependencies(vtool.sver_c_wrapper.lib_fname)
         except Exception:
             pass
-    return module_stdinfo_dict(vtool_ibeis, libdep=libdep)
+    return module_stdinfo_dict(vtool, libdep=libdep)
 
 
 #@checkinfo('1.1.7')

--- a/wbia/unstable/_grave_bayes.py
+++ b/wbia/unstable/_grave_bayes.py
@@ -105,7 +105,7 @@ def try_query(model, infr, evidence, interest_ttypes=[], verbose=True):
     if True:
         return bruteforce(model, query_vars=None, evidence=evidence)
     else:
-        import vtool_ibeis as vt
+        import vtool as vt
         query_vars = ut.setdiff_ordered(model.nodes(), list(evidence.keys()))
         # hack
         query_vars = ut.setdiff_ordered(query_vars, ut.list_getattr(model.ttype2_cpds['score'], 'variable'))
@@ -848,7 +848,7 @@ def flow():
     import pystruct.models  # NOQA
     import networkx as netx  # NOQA
 
-    import vtool_ibeis as vt
+    import vtool as vt
     num_annots = 10
     num_names = num_annots
     hidden_nids = np.random.randint(0, num_names, num_annots)
@@ -860,7 +860,7 @@ def flow():
     }
 
     if True:
-        import vtool_ibeis as vt
+        import vtool as vt
         import wbia.plottool as pt
         xdata = np.linspace(0, 100, 1000)
         tp_pdf = vt.gauss_func1d(xdata, **toy_params[True])

--- a/wbia/unstable/_scriptvsone_grave.py
+++ b/wbia/unstable/_scriptvsone_grave.py
@@ -6,7 +6,7 @@ import utool as ut
 
 def load_multiclass_scores(self):
     # convert simple scores to multiclass scores
-    import vtool_ibeis as vt
+    import vtool as vt
     self.multiclass_scores = {}
     for key in self.samples.simple_scores.keys():
         scores = self.samples.simple_scores[key].values
@@ -155,7 +155,7 @@ def bigcache_vsone(qreq_, hyper_params):
         >>> qreq_ = self.qreq_
         >>> hyper_params = self.hyper_params
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia
     # Get a set of training pairs
     ibs = qreq_.ibs
@@ -304,7 +304,7 @@ def bigcache_vsone(qreq_, hyper_params):
         >>> qreq_ = self.qreq_
         >>> hyper_params = self.hyper_params
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia
     # Get a set of training pairs
     ibs = qreq_.ibs

--- a/wbia/unstable/bayes.py
+++ b/wbia/unstable/bayes.py
@@ -330,7 +330,7 @@ def make_temp_state(state):
 
 def collapse_labels(model, evidence, reduced_variables, reduced_row_idxs,
                     reduced_values):
-    import vtool_ibeis as vt
+    import vtool as vt
     #assert np.all(reduced_joint.values.ravel() == reduced_joint.values.flatten())
     reduced_ttypes = [model.var2_cpd[var].ttype for var in reduced_variables]
 
@@ -450,7 +450,7 @@ def collapse_factor_labels(model, reduced_joint, evidence):
 
 def report_partitioning_statistics(new_reduced_joint):
     # compute partitioning statistics
-    import vtool_ibeis as vt
+    import vtool as vt
     vals, idxs = vt.group_indices(new_reduced_joint.values.ravel())
     #groupsize = list(map(len, idxs))
     #groupassigns = ut.unflat_vecmap(new_reduced_joint.assignment, idxs)

--- a/wbia/unstable/crf.py
+++ b/wbia/unstable/crf.py
@@ -52,7 +52,7 @@ def crftest():
         False: {'mu': 7.0, 'sigma': .9}
     }
     if False:
-        import vtool_ibeis as vt
+        import vtool as vt
         import wbia.plottool as pt
         pt.ensureqt()
         xdata = np.linspace(0, 100, 1000)

--- a/wbia/unstable/demobayes.py
+++ b/wbia/unstable/demobayes.py
@@ -203,7 +203,7 @@ def classify_k(cfg={}):
 
 
 def show_toy_distributions(toy_params):
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia.plottool as pt
     pt.ensureqt()
     xdata = np.linspace(0, 8, 1000)
@@ -241,7 +241,7 @@ def get_toy_data_1vM(num_annots, num_names=None, **kwargs):
         >>> import wbia.plottool as pt
         >>> ut.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     tup_ = get_toy_annots(num_annots, num_names, **kwargs)
     aids, nids, aids1, nids1, all_aids, all_nids = tup_
     rng = vt.ensure_rng(None)
@@ -383,7 +383,7 @@ def get_toy_annots(num_annots, num_names=None, initial_aids=None, initial_nids=N
         >>> result = ('(aids, nids, aids1, nids1, all_aids, all_nids) = %s' % (ut.repr2((aids, nids, aids1, nids1, all_aids, all_nids), nl=1),))
         >>> print(result)
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     if num_names is None:
         num_names = num_annots
     print('Generating toy data with num_annots=%r' % (num_annots,))
@@ -472,7 +472,7 @@ def get_toy_data_1v1(num_annots=5, num_names=None, **kwargs):
         >>> num_annots = 1000
         >>> num_names = 400
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     tup_ = get_toy_annots(num_annots, num_names, **kwargs)
     aids, nids, aids1, nids1, all_aids, all_nids = tup_
     rng = vt.ensure_rng(None)
@@ -564,7 +564,7 @@ def learn_prob_score(num_scores=5, pad=55, ret_enc=False, use_cache=None):
     #diag_labels = pairwise_matches.compress(is_diag)
 
     # Learn P(S_{ij} | M_{ij})
-    import vtool_ibeis as vt
+    import vtool as vt
     encoder = vt.ScoreNormalizer(
         reverse=True, monotonize=True,
         adjust=4,

--- a/wbia/unstable/distinctiveness_normalizer.py
+++ b/wbia/unstable/distinctiveness_normalizer.py
@@ -191,7 +191,7 @@ class DistinctivnessNormalizer(ut.Cachable):
 
     def load_or_build_flann(dstcnvs_normer, cachedir=None, verbose=True, *args,
                             **kwargs):
-        from vtool_ibeis._pyflann_backend import pyflann as pyflann
+        from vtool._pyflann_backend import pyflann as pyflann
         flann_fpath = dstcnvs_normer.get_flann_fpath(cachedir)
         if ut.checkpath(flann_fpath, verbose=ut.VERBOSE):
             try:

--- a/wbia/unstable/iccv.py
+++ b/wbia/unstable/iccv.py
@@ -422,7 +422,7 @@ def draw_cmcs(dbname):
         >>> print(result)
     """
     # DRAW RESULTS
-    import vtool_ibeis as vt
+    import vtool as vt
     import wbia.plottool as pt
     import pathlib
     if dbname is None:
@@ -492,7 +492,7 @@ def iccv_roc(dbname):
         >>> print(result)
     """
     import wbia.plottool as pt
-    import vtool_ibeis as vt
+    import vtool as vt
     from wbia.scripts.script_vsone import OneVsOneProblem
     ibs, expt_aids, train_aids, test_aids, species = iccv_data(dbname)
     pt.qtensure()
@@ -617,7 +617,7 @@ def draw_saved_roc(dbname):
     # DRAW RESULTS
     import wbia.plottool as pt
     import sklearn.metrics
-    import vtool_ibeis as vt
+    import vtool as vt
     import matplotlib as mpl
     pt.qtensure()
 
@@ -1136,7 +1136,7 @@ def draw_ete(dbname):
     plot_fpath = plot_fpath.parent.joinpath('fig_' + plot_fpath.stem + plot_fpath.suffix)
     # .joinpath('ete_%s.png' % (dbname))
     fig.savefig(str(plot_fpath))
-    import vtool_ibeis as vt
+    import vtool as vt
     clip_fpath = vt.clipwhite_ondisk(str(plot_fpath))
     print('plot_fpath = %r' % (plot_fpath,))
     print('clip_fpath = %r' % (clip_fpath,))

--- a/wbia/unstable/multi_index.py
+++ b/wbia/unstable/multi_index.py
@@ -10,7 +10,7 @@ import six
 from six.moves import zip, map, range
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from wbia.algo.hots import neighbor_index_cache
 from wbia.algo.hots import hstypes
 

--- a/wbia/unstable/old_dbinfo_dan.py
+++ b/wbia/unstable/old_dbinfo_dan.py
@@ -352,7 +352,7 @@ def split_analysis(ibs):
         aid_pairs = [annots.get_aidpairs() for annots in annots_list]
 
     speeds_list = ibs.unflat_map(ibs.get_annotpair_speeds, aid_pairs)
-    import vtool_ibeis as vt
+    import vtool as vt
     max_speeds = np.array([vt.safe_max(s, nans=False) for s in speeds_list])
 
     nan_idx = np.where(np.isnan(max_speeds))[0]
@@ -1028,7 +1028,7 @@ def print_feature_info(testres):
         >>> import wbia.plottool as pt
         >>> ut.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     #ibs = testres.ibs
     def print_feat_stats(kpts, vecs):
         assert len(vecs) == len(kpts), 'disagreement'

--- a/wbia/unstable/old_vsone.py
+++ b/wbia/unstable/old_vsone.py
@@ -213,7 +213,7 @@ def prepare_annot_pairs(ibs, qaids, daids, qconfig2_, dconfig2_):
 def gridsearch_ratio_thresh(matches):
     import sklearn
     import sklearn.metrics
-    import vtool_ibeis as vt
+    import vtool as vt
     # Param search for vsone
     import wbia.plottool as pt
     pt.qt4ensure()

--- a/wbia/unstable/orig_graph_iden.py
+++ b/wbia/unstable/orig_graph_iden.py
@@ -5,7 +5,7 @@ TODO: use graph_iden.py instead.  Need to encapsulate some of this functionality
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt  # NOQA
+import vtool as vt  # NOQA
 import six
 print, rrr, profile = ut.inject2(__name__)
 

--- a/wbia/unstable/pgm_ext.py
+++ b/wbia/unstable/pgm_ext.py
@@ -191,7 +191,7 @@ class ApproximateFactor(object):
             return phi
 
     def _compute_unique_state_ids(self):
-        import vtool_ibeis as vt
+        import vtool as vt
         #data_ids = vt.compute_ndarray_unique_rowids_unsafe(self.state_idxs)
         data_ids = np.array(vt.compute_unique_data_ids_(list(map(tuple, self.state_idxs))))
         return data_ids
@@ -217,7 +217,7 @@ class ApproximateFactor(object):
             | v1_1 | v2_0 | v3_2 |                0.1000 |
             +------+------+------+-----------------------+
         """
-        import vtool_ibeis as vt
+        import vtool as vt
 
         phi = self.copy() if inplace else self
         #data_ids = vt.compute_ndarray_unique_rowids_unsafe(self.state_idxs)

--- a/wbia/unstable/scorenorm.py
+++ b/wbia/unstable/scorenorm.py
@@ -33,7 +33,7 @@ import re
 from wbia import dtool
 import numpy as np
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import six  # NOQA
 from functools import partial
 from os.path import join
@@ -433,7 +433,7 @@ def learn_annotscore_normalizer(qreq_, learnkw={}):
         qreq_ (wbia.QueryRequest):  query request object with hyper-parameters
 
     Returns:
-        vtool_ibeis.ScoreNormalizer: encoder
+        vtool.ScoreNormalizer: encoder
 
     CommandLine:
         python -m wbia --tf learn_annotscore_normalizer --show
@@ -554,7 +554,7 @@ def learn_featscore_normalizer(qreq_, datakw={}, learnkw={}):
         qreq_ (wbia.QueryRequest):  query request object with hyper-parameters
 
     Returns:
-        vtool_ibeis.ScoreNormalizer: encoder
+        vtool.ScoreNormalizer: encoder
 
     CommandLine:
         python -m wbia --tf learn_featscore_normalizer --show -t default:

--- a/wbia/unstable/script_bp_cut.py
+++ b/wbia/unstable/script_bp_cut.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, division, absolute_import
 import numpy as np
 import pandas as pd
-import vtool_ibeis as vt  # NOQA
+import vtool as vt  # NOQA
 import networkx as nx
 import opengm
 import wbia.plottool as pt  # NOQA

--- a/wbia/unstable/testem.py
+++ b/wbia/unstable/testem.py
@@ -239,7 +239,7 @@ def try_rf_classifier():
 
 
 def make_test_pairwise_fetaures(case1, case2, label, rng):
-    import vtool_ibeis as vt
+    import vtool as vt
     mu_fm = 50 if label == 1 else 10
     sigma_fm = 10 if label == 1 else 20
     mu_fs = .2 if label == 1 else .4
@@ -267,7 +267,7 @@ def make_test_pairwise_fetaures(case1, case2, label, rng):
 
 
 def make_test_pairwise_labels(case1, case2):
-    import vtool_ibeis as vt
+    import vtool as vt
     is_same = case1['name'] == case2['name']
     yaw1 = case1['yaw']
     yaw2 = case2['yaw']
@@ -289,7 +289,7 @@ def make_test_pairwise_labels(case1, case2):
 
 
 def make_test_pairwise_labels2(cases1, cases2):
-    import vtool_ibeis as vt
+    import vtool as vt
     is_same = np.array(cases1['name']) == np.array(cases2['name'])
     yaw1 = np.array(cases1['yaw'])
     yaw2 = np.array(cases2['yaw'])
@@ -360,7 +360,7 @@ def try_em():
         #     'B':  1 * tau / 4,
         #     'R':  2 * tau / 4,
         # }
-        import vtool_ibeis as vt
+        import vtool as vt
 
         nid_list = np.array(ut.dict_take_column(test_case, 'name'))
         yaw_list = np.array(ut.dict_take(view_to_ori, ut.dict_take_column(test_case, 'view')))

--- a/wbia/viz/interact/interact_chip.py
+++ b/wbia/viz/interact/interact_chip.py
@@ -8,7 +8,7 @@ CommandLine:
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import wbia.plottool as pt  # NOQA
 from functools import partial
 from wbia import viz

--- a/wbia/viz/interact/interact_image.py
+++ b/wbia/viz/interact/interact_image.py
@@ -54,7 +54,7 @@ def ishow_image(ibs, gid, sel_aids=[], fnum=None, select_callback=None,
             x, y = event.xdata, event.ydata
             # Find ANNOTATION center nearest to the clicked point
             aid_list = vh.get_ibsdat(ax, 'aid_list', default=[])
-            import vtool_ibeis as vt
+            import vtool as vt
             centx, _dist = vt.nearest_point(x, y, annotation_centers)
             aid = aid_list[centx]
             print(' ...clicked aid=%r' % aid)

--- a/wbia/viz/viz_chip.py
+++ b/wbia/viz/viz_chip.py
@@ -93,7 +93,7 @@ def show_many_chips(ibs, aid_list, config2_=None, fnum=None, pnum=None, vert=Tru
         print('[viz] show_many_chips')
     in_image = False
     chip_list = vh.get_chips(ibs, aid_list, in_image=in_image, config2_=config2_)
-    import vtool_ibeis as vt
+    import vtool as vt
     stacked_chips = vt.stack_image_recurse(chip_list, modifysize=True, vert=vert)
     pt.imshow(stacked_chips, fnum=None, pnum=None)
 
@@ -137,7 +137,7 @@ def show_chip(ibs, aid, in_image=False, annote=True, title_suffix='',
         >>> # VIZ_TEST
         >>> from wbia.viz.viz_chip import *  # NOQA
         >>> import numpy as np
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> in_image = False
         >>> ibs, aid_list, kwargs, config2_ = testdata_showchip()
         >>> aid = aid_list[0]
@@ -216,7 +216,7 @@ def show_chip(ibs, aid, in_image=False, annote=True, title_suffix='',
 
         zoom_ = ut.get_argval('--zoom', type_=float, default=None)
         if zoom_ is not None:
-            import vtool_ibeis as vt
+            import vtool as vt
             # Zoom into the chip for some image context
             rotated_verts = ibs.get_annot_rotated_verts(aid)
             bbox = ibs.get_annot_bboxes(aid)

--- a/wbia/viz/viz_graph.py
+++ b/wbia/viz/viz_graph.py
@@ -12,7 +12,7 @@ WindowsDepends:
 from __future__ import absolute_import, division, print_function, unicode_literals
 import six
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from wbia import dtool
 import numpy as np  # NOQA
 import itertools

--- a/wbia/viz/viz_graph2.py
+++ b/wbia/viz/viz_graph2.py
@@ -6,7 +6,7 @@ CommandLine:
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 from wbia import dtool
 import networkx as nx

--- a/wbia/viz/viz_helpers.py
+++ b/wbia/viz/viz_helpers.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
 import utool as ut
-import vtool_ibeis.keypoint as ktool
+import vtool.keypoint as ktool
 import wbia.plottool.draw_func2 as df2
 from six.moves import zip, map
 from wbia.plottool import plot_helpers as ph

--- a/wbia/viz/viz_hough.py
+++ b/wbia/viz/viz_hough.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 from wbia.viz import viz_helpers as vh
 from wbia.algo.detect import randomforest
 from os.path import splitext

--- a/wbia/viz/viz_matches.py
+++ b/wbia/viz/viz_matches.py
@@ -110,7 +110,7 @@ def show_name_matches(ibs, qaid, name_daid_list, name_fm_list, name_fs_list,
         >>> from wbia.viz.viz_matches import *  # NOQA
         >>> from wbia.algo.hots import chip_match
         >>> from wbia.algo.hots import name_scoring
-        >>> import vtool_ibeis as vt
+        >>> import vtool as vt
         >>> from wbia.algo.hots import _pipeline_helpers as plh  # NOQA
         >>> import numpy as np
         >>> func = chip_match.ChipMatch.show_single_namematch
@@ -148,9 +148,9 @@ def show_name_matches(ibs, qaid, name_daid_list, name_fm_list, name_fs_list,
 
     heatmask = kwargs.pop('heatmask', False)
     if heatmask:
-        from vtool_ibeis.coverage_kpts import make_kpts_heatmask
+        from vtool.coverage_kpts import make_kpts_heatmask
         import numpy as np
-        import vtool_ibeis as vt
+        import vtool as vt
 
         wh1 = vt.get_size(rchip1)
         fx1 = np.unique(np.hstack([fm.T[0] for fm in name_fm_list]))
@@ -580,10 +580,10 @@ def show_multichip_match(rchip1, rchip2_list, kpts1, kpts2_list, fm_list,
     target_wh = None
 
     """
-    import vtool_ibeis.image as gtool
+    import vtool.image as gtool
     import wbia.plottool as pt
     import numpy as np
-    import vtool_ibeis as vt
+    import vtool as vt
     kwargs = kwargs.copy()
 
     colorbar_ = kwargs.pop('colorbar_', True)

--- a/wbia/viz/viz_name.py
+++ b/wbia/viz/viz_name.py
@@ -177,7 +177,7 @@ def show_multiple_chips(ibs, aid_list, in_image=True, fnum=0, sel_aids=[],
             # References:
             # http://stackoverflow.com/questions/17543359/drawing-lines-between-two-plots-in-matplotlib
             import matplotlib as mpl
-            import vtool_ibeis as vt
+            import vtool as vt
             # !!!
             #http://matplotlib.org/users/transforms_tutorial.html
 

--- a/wbia/viz/viz_nearest_descriptors.py
+++ b/wbia/viz/viz_nearest_descriptors.py
@@ -105,7 +105,7 @@ def show_top_featmatches(qreq_, cm_list):
     # for cm in cm_list:
     #     cm.score_annot_csum(qreq_)
     import numpy as np
-    import vtool_ibeis as vt
+    import vtool as vt
     from functools import partial
     # Stack chipmatches
     ibs = qreq_.ibs

--- a/wbia/viz/viz_other.py
+++ b/wbia/viz/viz_other.py
@@ -25,7 +25,7 @@ def chip_montage(ibs, qaids, config=None):
         >>> import wbia.plottool as pt
         >>> ut.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     chip_list = ibs.get_annot_chips(qaids, config2_=config)
     height = 2000
     dsize = (int(height * ut.PHI), height)
@@ -54,7 +54,7 @@ def image_montage(ibs, gids, config=None):
         >>> import wbia.plottool as pt
         >>> ut.show_if_requested()
     """
-    import vtool_ibeis as vt
+    import vtool as vt
     img_list = ibs.get_images(gids, config2_=config)
     height = 2000
     dsize = (int(height * ut.PHI), height)

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -12,7 +12,7 @@ from flask import request, current_app, send_file
 from wbia.control import controller_inject
 from wbia.web import appfuncs as appf
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import uuid as uuid_module
 import six
 from wbia.web.app import PROMETHEUS

--- a/wbia/web/appfuncs.py
+++ b/wbia/web/appfuncs.py
@@ -570,10 +570,10 @@ def convert_viewpoint_to_tuple(viewpoint_text):
 def _resize(image, t_width=None, t_height=None):
     """
     TODO:
-        # use vtool_ibeis instead
+        # use vtool instead
     """
     if False:
-        import vtool_ibeis as vt
+        import vtool as vt
         maxdims = (int(round(t_width)), int(round(t_height)))
         interpolation = 'linear'
         return vt.resize_to_maxdims(image, maxdims, interpolation)

--- a/wbia/web/routes_ajax.py
+++ b/wbia/web/routes_ajax.py
@@ -7,7 +7,7 @@ from flask import request, make_response, current_app
 from wbia.control import controller_inject
 from wbia.web import appfuncs as appf
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 
 (print, rrr, profile) = ut.inject2(__name__)
 

--- a/wbia/web/routes_experiments.py
+++ b/wbia/web/routes_experiments.py
@@ -7,7 +7,7 @@ from wbia.control import controller_inject
 from wbia.web import appfuncs as appf
 from os.path import abspath, expanduser, join
 import utool as ut
-import vtool_ibeis as vt
+import vtool as vt
 import numpy as np
 import cv2
 


### PR DESCRIPTION
- Change requirement "vtool_ibeis" to "wbia-vtool"

  We changed the vtool distribution name to "wbia-vtool".

- Rename vtool_ibeis import references to vtool

  We have renamed wbia-vtool package name from vtool_ibeis to vtool.
  
  ```
  git grep -l vtool_ibeis README.rst wbia | xargs sed -i \
      's/\([^/]\)vtool_ibeis/\1vtool/g'
  ```
