### PR TITLE
Update repo urls in provision Dockerfile

### DIFF
--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -10,38 +10,38 @@ ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
 # Clone IBEIS VSTS repositories
-RUN git clone --branch next https://github.com/WildbookOrg/brambox                     /wbia/brambox \
- && git clone --branch master https://github.com/WildbookOrg/flann                     /wbia/flann \
- && git clone --branch master https://github.com/WildbookOrg/hesaff                    /wbia/hesaff \
- && git clone --branch next https://github.com/WildbookOrg/ibeis-flukematch-module     /wbia/ibeis-flukematch-module \
- && git clone --branch next https://github.com/WildbookOrg/ibeis-curvrank-module       /wbia/ibeis-curvrank-module \
- && git clone --branch next https://github.com/WildbookOrg/ibeis-deepsense-module      /wbia/ibeis-deepsense-module \
- && git clone --branch next https://github.com/WildbookOrg/ibeis-finfindr-module       /wbia/ibeis-finfindr-module \
- && git clone --branch next https://github.com/WildbookOrg/ibeis-kaggle7-module        /wbia/ibeis-kaggle7-module \
- && git clone --branch next https://github.com/WildbookOrg/wbia-2d-orientation-module /wbia/wbia-2d-orientation-module \
- && git clone --branch master https://github.com/WildbookOrg/wbia                     /wbia/wbia \
- && git clone --branch next https://github.com/WildbookOrg/ibeis_cnn                   /wbia/ibeis_cnn \
- && git clone --branch next https://github.com/WildbookOrg/lightnet                    /wbia/lightnet \
- && git clone --branch next https://github.com/WildbookOrg/pydarknet                   /wbia/pydarknet \
- && git clone --branch next https://github.com/WildbookOrg/pyrf                        /wbia/pyrf \
- && git clone --branch next https://github.com/WildbookOrg/utool                       /wbia/utool \
- && git clone --branch master https://github.com/WildbookOrg/vtool                     /wbia/vtool
+RUN git clone --branch next https://github.com/WildbookOrg/wbia-tpl-brambox           /wbia/brambox \
+ && git clone --branch master https://github.com/WildbookOrg/wbia-tpl-pyflann         /wbia/flann \
+ && git clone --branch master https://github.com/WildbookOrg/wbia-tpl-pyhesaff        /wbia/hesaff \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-plugin-flukematch     /wbia/wbia-plugin-flukematch \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-plugin-curvrank       /wbia/wbia-plugin-curvrank \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-plugin-deepsense      /wbia/wbia-plugin-deepsense \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-plugin-finfindr       /wbia/wbia-plugin-finfindr \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-plugin-kaggle7        /wbia/wbia-plugin-kaggle7 \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-plugin-2d-orientation /wbia/wbia-plugin-2d-orientation \
+ && git clone --branch master https://github.com/WildbookOrg/wildbook-ia              /wbia/wildbook-ia \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-plugin-cnn            /wbia/wbia-plugin-cnn \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-tpl-lightnet          /wbia/lightnet \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-tpl-pydarknet         /wbia/pydarknet \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-tpl-pyrf              /wbia/pyrf \
+ && git clone --branch next https://github.com/WildbookOrg/wbia-utool                 /wbia/utool \
+ && git clone --branch master https://github.com/WildbookOrg/wbia-vtool               /wbia/vtool
 
-RUN cd /wbia/ibeis-curvrank-module/ibeis_curvrank \
+RUN cd /wbia/wbia-plugin-curvrank/wbia_curvrank \
  && git init \
- && git remote add vs https://github.com/WildbookOrg/ibeis_curvrank \
+ && git remote add vs https://github.com/WildbookOrg/wbia-tpl-curvrank \
  && git fetch vs \
  && git checkout functional-wbia
 
-RUN cd /wbia/ibeis-kaggle7-module/wbia_kaggle7 \
+RUN cd /wbia/wbia-plugin-kaggle7/wbia_kaggle7 \
  && git init \
- && git remote add vs https://github.com/WildbookOrg/whale-identification-2018 \
+ && git remote add vs https://github.com/WildbookOrg/wbia-tpl-kaggle7 \
  && git fetch vs \
  && git checkout next
 
-RUN cd /wbia/wbia-2d-orientation-module/wbia_2d_orientation \
+RUN cd /wbia/wbia-plugin-2d-orientation/wbia_2d_orientation \
  && git init \
- && git remote add vs https://github.com/WildbookOrg/2D-Orientation-v2 \
+ && git remote add vs https://github.com/WildbookOrg/wbia-tpl-2d-orientation \
  && git fetch vs \
  && git checkout plugin
 
@@ -75,9 +75,9 @@ RUN . /virtualenv/env3/bin/activate \
  && cd /wbia/lightnet \
  && /virtualenv/env3/bin/pip install -r requirements.txt \
  && /virtualenv/env3/bin/pip install -r develop.txt \
- && cd /wbia/ibeis-flukematch-module \
+ && cd /wbia/wbia-plugin-flukematch \
  && /bin/bash unix_build.sh \
- && cd /wbia/ibeis-curvrank-module \
+ && cd /wbia/wbia-plugin-curvrank \
  && /bin/bash unix_build.sh \
  && cd /wbia/pydarknet \
  && /bin/bash unix_build.sh \
@@ -89,7 +89,7 @@ RUN . /virtualenv/env3/bin/activate \
 
 # Install Python repositories
 RUN . /virtualenv/env3/bin/activate \
- && cd /wbia/ibeis_cnn \
+ && cd /wbia/wbia-plugin-cnn \
  && pip install -e . \
  && cd /wbia/hesaff \
  && pip install -e . \
@@ -105,17 +105,17 @@ RUN . /virtualenv/env3/bin/activate \
  && pip install -e . \
  && cd /wbia/vtool \
  && pip install -e . \
- && cd /wbia/wbia \
+ && cd /wbia/wildbook-ia \
  && pip install -e . \
- && cd /wbia/ibeis-flukematch-module \
+ && cd /wbia/wbia-plugin-flukematch \
  && pip install -e . \
- && cd /wbia/ibeis-curvrank-module \
+ && cd /wbia/wbia-plugin-curvrank \
  && pip install -e . \
- && cd /wbia/ibeis-deepsense-module \
+ && cd /wbia/wbia-plugin-deepsense \
  && pip install -e . \
- && cd /wbia/ibeis-finfindr-module \
+ && cd /wbia/wbia-plugin-finfindr \
  && pip install -e . \
- && cd /wbia/ibeis-kaggle7-module \
+ && cd /wbia/wbia-plugin-kaggle7 \
  && pip install -e . \
  && cd /wbia/wbia-2d-orientation-module \
  && pip install -e .


### PR DESCRIPTION
Repos have been renamed in github, for example:

- `utool` -> `wbia-utool`
- `flann` -> `wbia-tpl-pyflann`
- `ibeis-curvrank-module` -> `wbia-plugin-curvrank`
- `ibeis_curvrank` -> `wbia-tpl-curvrank`