### PR TITLE
Fix import errors reported by doctests

### DIFF
--- a/wbia/algo/verif/sklearn_utils.py
+++ b/wbia/algo/verif/sklearn_utils.py
@@ -9,7 +9,7 @@ import pandas as pd
 from sklearn.utils.validation import check_array
 
 # from sklearn.utils import check_random_state
-from sklearn.externals.six.moves import zip
+from six.moves import zip
 
 # from sklearn.model_selection._split import (_BaseKFold, KFold)
 from sklearn.model_selection._split import _BaseKFold

--- a/wbia/dtool/_grave_depcache.py
+++ b/wbia/dtool/_grave_depcache.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
+import utool as ut
+
 from .base import BaseRequest
 
 

--- a/wbia/dtool/_grave_depcache.py
+++ b/wbia/dtool/_grave_depcache.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 # flake8: noqa
+from .base import BaseRequest
+
+
 def _add_dirty_rows(
     table, parent_rowids, config_rowid, isdirty_list, config, verbose=True
 ):

--- a/wbia/init/sysres.py
+++ b/wbia/init/sysres.py
@@ -151,7 +151,7 @@ def get_rawdir():
 
 def guiselect_workdir():
     """ Prompts the user to specify a work directory """
-    import wbia.guitool
+    from wbia import guitool
 
     guitool.ensure_qtapp()
     # Gui selection


### PR DESCRIPTION
- Add import for BaseRequest in dtool/_grave_depcache.py

  Missing import reported when running doctests:
  
  ```
  Traceback (most recent call last):
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/utils/util_import.py", line 187, in _custom_import_modpath
      module = import_module_from_name(modname)
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/utils/util_import.py", line 345, in import_module_from_name
      module = importlib.import_module(modname)
    File "/virtualenv/env3/lib/python3.6/importlib/__init__.py", line 126, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 994, in _gcd_import
    File "<frozen importlib._bootstrap>", line 971, in _find_and_load
    File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 678, in exec_module
    File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
    File "/wbia/wildbook-ia/wbia/dtool/_grave_depcache.py", line 138, in <module>
      class AlgoRequest(BaseRequest, ut.NiceRepr):
  NameError: name 'BaseRequest' is not defined
  ```

- Add "import utool" to dtool/_grave_depcache.py

  Missing import reported when running doctests:
  
  ```
  Traceback (most recent call last):
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/utils/util_import.py", line 187, in _custom_import_modpath
      module = import_module_from_name(modname)
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/utils/util_import.py", line 345, in import_module_from_name
      module = importlib.import_module(modname)
    File "/virtualenv/env3/lib/python3.6/importlib/__init__.py", line 126, in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
    File "<frozen importlib._bootstrap>", line 994, in _gcd_import
    File "<frozen importlib._bootstrap>", line 971, in _find_and_load
    File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
    File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 678, in exec_module
    File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
    File "/wbia/wildbook-ia/wbia/dtool/_grave_depcache.py", line 141, in <module>
      class AlgoRequest(BaseRequest, ut.NiceRepr):
  NameError: name 'ut' is not defined
  ```

- Import "six" directly instead of "sklearn.externals.six"

  "sklearn.externals.six" was removed from scikit-learn
  [v0.21](https://scikit-learn.org/dev/whats_new/v0.21.html#sklearn-externals)
  and the
  [PR](https://github.com/scikit-learn/scikit-learn/pull/12916)
  said users should rely on the offical version of six instead of the one
  in scikit-learn.

- Fix guitool import in init/sysres.py

  When running doctests:
  
  ```
  DOCTEST TRACEBACK
  Traceback (most recent call last):
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 553, in run
      exec(code, test_globals)
    File "<doctest:/wbia/wildbook-ia/wbia/gui/id_review_api.py::make_ensure_match_img_nosql_func:0>", line rel: 5, abs: 669, in <module>
      >>> cm, qreq_ = wbia.testdata_cm()
    File "/wbia/wildbook-ia/wbia/init/main_helpers.py", line 524, in testdata_cm
      a=a,
    File "/wbia/wildbook-ia/wbia/init/main_helpers.py", line 494, in testdata_cmlist
      a=a,
    File "/wbia/wildbook-ia/wbia/init/main_helpers.py", line 451, in testdata_qreq_
      **kwargs,
    File "/wbia/wildbook-ia/wbia/init/main_helpers.py", line 342, in testdata_expanded_aids
      ibs = wbia.opendb(defaultdb=defaultdb)
    File "/wbia/wildbook-ia/wbia/main_module.py", line 594, in opendb
      defaultdb=defaultdb, allow_newdir=allow_newdir, db=db, dbdir=dbdir
    File "/wbia/wildbook-ia/wbia/init/sysres.py", line 346, in get_args_dbdir
      return db_to_dbdir(defaultdb, allow_newdir=allow_newdir)
    File "/wbia/wildbook-ia/wbia/init/sysres.py", line 219, in db_to_dbdir
      work_dir = get_workdir()
    File "/wbia/wildbook-ia/wbia/init/sysres.py", line 92, in get_workdir
      work_dir = set_workdir()
    File "/wbia/wildbook-ia/wbia/init/sysres.py", line 121, in set_workdir
      work_dir = guiselect_workdir()
    File "/wbia/wildbook-ia/wbia/init/sysres.py", line 156, in guiselect_workdir
      guitool.ensure_qtapp()
  NameError: name 'guitool' is not defined
  ```
  
  This is because we imported guitool like this `import wbia.guitool`, instead I
  changed it to `from wbia import guitool`.
