### PR TITLE
Creating a runtime oriented container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,21 +72,6 @@ RUN set -x \
        unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Install system dependencies
-RUN set -x \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       # sort: alphabetically
-       wget \
-    && rm -rf /var/lib/apt/lists/*
-# Install Docker
-# ??? DinD... is this wise?
-RUN set -x \
-    && wget -O /tmp/get-docker.sh https://get.docker.com \
-    && sh /tmp/get-docker.sh \
-    && rm -rf /tmp/get-docker.sh \
-    && rm -rf /var/lib/apt/lists/* 
-
 # Install CNMeM, a memory manager for CUDA
 COPY --from=cnmem-build /usr/local/lib/libcnmem.so* /usr/local/lib/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,8 @@ RUN set -x \
        #: opencv2 dependency
        libxext6 \
        #: dev debug dependency
+       #: python3-dev required to build 'annoy'
+       python3-dev \
        python3-gdbm \
        python3-pip \
        python3-setuptools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,8 @@ RUN set -x \
        libxrender1 \
        #: opencv2 dependency
        libxext6 \
+       #: opencv2 dependency
+       libgl1 \
        #: dev debug dependency
        #: python3-dev required to build 'annoy'
        python3-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,117 @@
+FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04
+
+MAINTAINER Wild Me <dev@wildme.org>
+
+# Fix for ubuntu 18.04 container https://stackoverflow.com/a/58173981/176882
+ENV LANG C.UTF-8
+
+USER root
+
+
+# ###
+# System setup
+# ###
+
+# Create runtime user "wbia" (aka WildBook IA)
+RUN set -x \
+    && addgroup --system wbia \
+    && adduser --system --group wbia
+
+# Install system dependencies
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       # ** Please sort alphabetically **
+       ca-certificates \
+       #: opencv2 dep
+       libglib2.0-0 \
+       #: opencv2 dependency
+       libsm6 \
+       #: opencv2 dependency
+       libxrender1 \
+       #: opencv2 dependency
+       libxext6 \
+       #: dev debug dependency
+       python3-gdbm \
+       python3-pip \
+       python3-setuptools \
+       python3-venv \
+       unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install system dependencies
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       # sort: alphabetically
+       wget \
+    && rm -rf /var/lib/apt/lists/*
+# Install Docker
+# ??? DinD... is this wise?
+RUN set -x \
+    && wget -O /tmp/get-docker.sh https://get.docker.com \
+    && sh /tmp/get-docker.sh \
+    && rm -rf /tmp/get-docker.sh \
+    && rm -rf /var/lib/apt/lists/* 
+
+# TODO (4-Jun-12020) Install CNMeM as part of a separate build stage
+# Install system dependencies
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       # sort: alphabetically
+       git \
+       cmake \       
+    && rm -rf /var/lib/apt/lists/*
+# Install CNMeM, a memory manager for CUDA
+RUN git clone https://github.com/NVIDIA/cnmem.git /tmp/cnmem \
+ && cd /tmp/cnmem/ \
+ && git checkout v1.0.0 \
+ && mkdir -p /tmp/cnmem/build \
+ && cd /tmp/cnmem/build \
+ && cmake .. \
+ && make -j4 \
+ && make install \
+ && cd .. \
+ && rm -rf /tmp/cnmem
+
+# Set CUDA-specific environment paths
+ENV PATH "/usr/local/cuda/bin:${PATH}"
+ENV LD_LIBRARY_PATH "/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+ENV CUDA_HOME "/usr/local/cuda"
+
+# Create the working directory
+RUN set -x \
+    && mkdir -p /data\
+    && chown wbia:wbia /data \
+    && chmod 755 /data
+
+# ###
+# Application setup
+# ###
+
+COPY . /tmp/code
+
+RUN set -x \
+    && cd /tmp/code \
+    && python3 -m pip install --upgrade pip \
+    && python3 -m pip install --verbose --no-deps . \
+    # Install pytorch early because it's a large package
+    && python3 -m pip install torch \
+    && python3 -m pip install -r /tmp/code/requirements/runtime.txt \
+    # TODO (4-Jun-12020) plugins will come in time...
+    # && python3 -m pip install -r /tmp/code/requirements.txt -r /tmp/code/requirements/plugins.txt
+    && rm -rf /tmp/code
+
+# Visual install verification of the OpenCV2 Python buildings
+RUN python3 -c "import cv2; print(cv2.getBuildInformation())"
+
+# Ports for the frontend web server
+EXPOSE 5000
+
+# Change to the runtime user
+WORKDIR /data
+USER wbia
+
+# FIXME (4-Jun-12020) Use entrypoint script so that it'll be versatile and capable of running different ways.
+ENTRYPOINT ["python3", "-m", "wbia.dev", "--dbdir", "/data/db", "--logdir", "/data/logs/", "--web", "--port", "5000", "--web-deterministic-ports", "--containerized", "--cpudark", "--production"]

--- a/devops/build.sh
+++ b/devops/build.sh
@@ -13,3 +13,7 @@ docker build -t wildme/wbia-base:latest base
 docker build -t wildme/wbia-dependencies:latest dependencies
 docker build -t wildme/wbia-provision:latest provision
 docker build -t wildme/wbia:latest .
+
+cd ../
+# Build the runtime container
+docker build -t wildbook/wildbook-ia:latest .

--- a/devops/publish.sh
+++ b/devops/publish.sh
@@ -26,7 +26,7 @@ else
 fi
 
 # Tag built images from `build.sh`, which tags as `latest`
-for IMG in wbia-base wbia-dependencies wbia-provision wbia; do
+for IMG in wbia-base wbia-dependencies wbia-provision wbia wildbook-ia; do
     echo "Tagging wildme/${IMG}:latest --> ${IMG_PREFIX}${IMG}:${TAG}"
     docker tag wildme/${IMG}:latest ${IMG_PREFIX}${IMG}:${TAG}
     echo "Pushing ${IMG_PREFIX}${IMG}:${TAG}"


### PR DESCRIPTION
This is a straight forward container that allows build workflows and dependency management tools to do the heavy lifting. We create the build dependencies as part of a build workflow and publish them to a package repository (i.e. PyPI). We then allow pip to pull in the dependencies. 

This removes the need to for build tools within the container, which is something we don't actually want laying around in a production worthy system.

---

Run using `docker build -t wildme/wildbook-ia .`