### PR TITLE
Update dockerfiles

### DIFF
--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -64,6 +64,8 @@ RUN apt-get update \
         gfortran=4:7.4.0-1ubuntu2.3 \
         tesseract-ocr=4.00~git2288-10f4998a-2 \
         tesseract-ocr-eng=4.00~git24-0e00fe6-1.2 \
+        liblz4-dev=0.0~r131-2ubuntu3 \
+        libhdf5-serial-dev=1.10.0-patch1+docs-4 \
  && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://get.docker.com -o get-docker.sh \

--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update \
         pkg-config=0.29.1-0ubuntu2 \
         libtbb2=2017~U7-8 \
         libtbb-dev=2017~U7-8 \
-        cmake \
         git \
         tmux=2.6-3 \
         locate=4.6.0+git+20170828-2 \
@@ -75,6 +74,9 @@ RUN mkdir -p /wbia
 
 # Create virtualenv location
 RUN mkdir -p /virtualenv
+
+# Install cmake and ninja
+RUN /usr/bin/pip3 install cmake ninja
 
 # Install CNMeM
 RUN git clone https://github.com/NVIDIA/cnmem.git /wbia/cnmem \

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -61,16 +61,11 @@ RUN . /virtualenv/env3/bin/activate \
  && pip install scikit-build
 
 # Build Python repositories with external codebases
-# TODO remove flann checkout v2.0.0 once the "next" branch is working
-# TODO remove hesaff checkout v2.0.0 once the "next" branch is working
-# TODO remove vtool checkout v2.0.0 once the "master" branch is working
 RUN . /virtualenv/env3/bin/activate \
  && cd /wbia/flann \
- && git checkout v2.0.0 \
- && /bin/bash unix_build.sh \
+ && /bin/bash run_developer_setup.sh \
  && cd /wbia/hesaff \
- && git checkout v2.0.0 \
- && /bin/bash unix_build.sh \
+ && /bin/bash run_developer_setup.sh \
  && cd /wbia/lightnet \
  && /virtualenv/env3/bin/pip install -r requirements.txt \
  && /virtualenv/env3/bin/pip install -r develop.txt \
@@ -81,10 +76,9 @@ RUN . /virtualenv/env3/bin/activate \
  && cd /wbia/pydarknet \
  && /bin/bash unix_build.sh \
  && cd /wbia/pyrf \
- && /bin/bash unix_build.sh \
+ && /bin/bash run_developer_setup.sh \
  && cd /wbia/vtool \
- && git checkout v2.0.0 \
- && /bin/bash unix_build.sh
+ && /bin/bash run_developer_setup.sh
 
 # Install Python repositories
 RUN . /virtualenv/env3/bin/activate \

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -76,7 +76,7 @@ RUN . /virtualenv/env3/bin/activate \
  && cd /wbia/pydarknet \
  && /bin/bash unix_build.sh \
  && cd /wbia/pyrf \
- && /bin/bash run_developer_setup.sh \
+ && /bin/bash unix_build.sh \
  && cd /wbia/vtool \
  && /bin/bash run_developer_setup.sh
 


### PR DESCRIPTION
- Use pip to install latest cmake in dockerfiles

  The cmake apt package in ubuntu 18.04 is 3.10, which is too old for
  flann, hesaff and vtool.  Instead of installing the cmake apt package,
  we can just install it using pip with the latest version.
  
  Remove apt install for cmake in base dockerfile and pip install cmake
  and ninja in provision dockerfile.

- Install latest flann, hesaff and vtool in dockerfiles

  We were installing the last tag `v2.0.0` for flann, hesaff and vtool
  because the cmake installed on ubuntu 18.04 was too old and also the
  build scripts weren't working.  Now that we have fixed the master
  branches of these repos, we can switch to using the latest versions
  again.

- Run pyrf unix_build.sh (not run_developer_setup) in dockerfile

  Some repos use `run_developer_setup.sh` and some use `unix_build.sh` and
  pyrf uses `unix_build.sh` but I accidentally changed it to
  `run_developer_setup.sh` in a previous commit.
