### PR TITLE
Fix cv2.so symlink in dependencies dockerfile

### DIFF
--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -74,7 +74,7 @@ RUN . /virtualenv/env3/bin/activate \
  && cd .. \
  && rm -rf /wbia/opencv/build
 
-RUN ln -s /virtualenv/env3/python/cv2/python-3.6/cv2.cpython-36m-x86_64-linux-gnu.so /virtualenv/env3/lib/python3.6/site-packages/cv2.so
+RUN ln -s /virtualenv/env3/lib/python3.6/site-packages/cv2/python-3.6/cv2.cpython-36m-x86_64-linux-gnu.so /virtualenv/env3/lib/python3.6/site-packages/cv2.so
 
 RUN /virtualenv/env3/bin/pip install \
     cython==0.28.1


### PR DESCRIPTION
When we upgraded opencv 3.4.4 to 3.4.10, for some reason, the so file
has moved from:

```
/virtualenv/env3/python/cv2/python-3.6/cv2.cpython-36m-x86_64-linux-gnu.so
```

to

```
/virtualenv/env3/lib/python3.6/site-packages/cv2/python-3.6/cv2.cpython-36m-x86_64-linux-gnu.so
```

Because the symlink was broken, we couldn't import anything from cv2:

```
>>> import cv2
>>> cv2.INTER_NEAREST
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'cv2' has no attribute 'INTER_NEAREST'
>>> cv2.__spec__
ModuleSpec(name='cv2', loader=None, origin='namespace', submodule_search_locations=_NamespacePath(['/virtualenv/env3/lib/python3.6/site-packages/cv2', '/virtualenv/env3/lib/python3.6/site-packages/cv2']))
```

---

~Just putting this fix out but I haven't actually finished building the docker images...  Will remove "WIP" when I finish testing...~