### PR TITLE
Change utool to wbia-utool in requirements file

### DIFF
--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -66,6 +66,8 @@ RUN . /virtualenv/env3/bin/activate \
  && /bin/bash run_developer_setup.sh \
  && cd /wbia/hesaff \
  && /bin/bash run_developer_setup.sh \
+ && cd /wbia/brambox \
+ && /virtualenv/env3/bin/pip install -e . \
  && cd /wbia/lightnet \
  && /virtualenv/env3/bin/pip install -r requirements.txt \
  && /virtualenv/env3/bin/pip install -r develop.txt \
@@ -85,8 +87,6 @@ RUN . /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-cnn \
  && pip install -e . \
  && cd /wbia/hesaff \
- && pip install -e . \
- && cd /wbia/brambox \
  && pip install -e . \
  && cd /wbia/lightnet \
  && pip install -e . \

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -37,5 +37,5 @@ statsmodels>=0.6.1
 tornado>=4.2.1
 ubelt >= 0.8.7
 
-utool >= 2.1.2
+wbia-utool >= 2.1.2
 wbia-vtool >= 2.1.0


### PR DESCRIPTION
- Change utool to wbia-utool in requirements files
  
  We changed the distribution name of our version of utool to wbia-utool.

- Install brambox before lightnet in dockerfile
  
  Lightnet depends on brambox and brambox (since we changed the
  distribution name to "wbia-brambox") isn't on pypi, causing lightnet
  installation to fail.  So install brambox before installing lightnet.
