### PR TITLE
Add virtualenv lib to LD_LIBRARY_PATH in dockerfile

### DIFF
--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -135,3 +135,6 @@ RUN cd /wbia/Theano \
  && /virtualenv/env3/bin/pip install -e . \
  && cd /wbia/networkx \
  && /virtualenv/env3/bin/pip install -e .
+
+# Include libraries in virtualenv for python
+ENV LD_LIBRARY_PATH "/virtualenv/env3/lib:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
When importing `pyhesaff` in the docker image:

```
(env3) root@fc31c00eaa09:/wbia/wildbook-ia# python
Python 3.6.9 (default, Apr 18 2020, 01:56:04)
[GCC 8.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyhesaff
[C!] Caught OSError:
libopencv_imgcodecs.so.3.4: cannot open shared object file: No such file or directory
[C!] cwd='/wbia/wildbook-ia'
[C!] load_clib(libname='hesaff' root_dir='/wbia/hesaff/pyhesaff')
[C!] lib_fpath = '/wbia/hesaff/pyhesaff/lib/libhesaff.so'
[C] Cannot LOAD 'hesaff' dynamic library. Is there a missing dependency?
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/wbia/hesaff/pyhesaff/__init__.py", line 9, in <module>
    from pyhesaff import _pyhesaff
  File "/wbia/hesaff/pyhesaff/_pyhesaff.py", line 196, in <module>
    HESAFF_CLIB, __LIB_FPATH__ = _load_hesaff_clib()
  File "/wbia/hesaff/pyhesaff/_pyhesaff.py", line 173, in _load_hesaff_clib
    (clib, def_cfunc, lib_fpath) = ctypes_interface.load_clib(libname, root_dir)
  File "/wbia/hesaff/pyhesaff/ctypes_interface.py", line 168, in load_clib
    raise ImportError(errmsg)
ImportError: [C] Cannot LOAD 'hesaff' dynamic library. Is there a missing dependency?
```

`libopencv_imgcodecs.so.3.4` (and lots of other libraries) is in
`/virtualenv/env3/lib` and it just needs to be added to `LD_LIBRARY_PATH` in
order for the libraries to be found.