### PR TITLE
Fix dev resetdbs script

### DIFF
--- a/wbia/other/ibsfuncs.py
+++ b/wbia/other/ibsfuncs.py
@@ -686,7 +686,7 @@ def check_image_loadable_worker(gpath, orient):
     except Exception:
         loadable = False
     try:
-        img = vt.imread(gpath, orient='auto', on_error='fail')
+        img = vt.imread(gpath, orient='auto')
         assert img is not None
     except Exception:
         exif = False

--- a/wbia/other/ibsfuncs.py
+++ b/wbia/other/ibsfuncs.py
@@ -882,7 +882,7 @@ def check_annot_corrupt_uuids(ibs, aid_list=None):
         for aid in aid_list:
             try:
                 ibs.get_annot_uuids(aid)
-            except Exception as ex:
+            except Exception:
                 failed_aids.append(aid)
         print('failed_aids = %r' % (failed_aids,))
         return failed_aids
@@ -1668,6 +1668,7 @@ def _make_unflat_getter_func(flat_getter):
         func = flat_getter
     funcname = get_funcname(func)
     assert funcname.startswith('get_'), 'only works on getters, not: ' + funcname
+
     # Create new function
     def unflat_getter(self, unflat_rowids, *args, **kwargs):
         # First flatten the list
@@ -6639,7 +6640,7 @@ def compute_ggr_fix_gps_names(ibs, min_diff=1800):  # 86,400 = 60 sec x 60 min X
             print('FOUND LOCATION FOR AID %d' % (aid,))
             print('\tDIFF   : %d H, %d M, %d S' % (h, m, s,))
             print('\tNEW GPS: %s' % (closest_gps,))
-    print('%d \ %d \ %d \ %d' % (num_all, num_bad, num_known, num_found,))
+    print(r'%d \ %d \ %d \ %d' % (num_all, num_bad, num_known, num_found,))
     return recovered_aid_list, recovered_gps_list, recovered_dist_list
 
 
@@ -7450,7 +7451,7 @@ def compute_ggr_fix_gps_contributors_gids(ibs, min_diff=600, individual=False):
                 not_found.add(note)
         else:
             not_found.add(note)
-    print('%d \ %d \ %d \ %d' % (num_all, num_bad, num_unrecovered, num_found,))
+    print(r'%d \ %d \ %d \ %d' % (num_all, num_bad, num_unrecovered, num_found,))
     num_recovered = len(recovered_gid_list)
     num_unrecovered = num_bad - len(recovered_gid_list)
     print('Missing GPS: %d' % (num_bad,))
@@ -7528,7 +7529,7 @@ def compute_ggr_fix_gps_contributors_aids(ibs, min_diff=600, individual=False):
                 not_found.add(note)
         else:
             not_found.add(note)
-    print('%d \ %d \ %d \ %d' % (num_all, num_bad, num_unrecovered, num_found,))
+    print(r'%d \ %d \ %d \ %d' % (num_all, num_bad, num_unrecovered, num_found,))
     num_recovered = len(recovered_aid_list)
     num_unrecovered = num_bad - len(recovered_aid_list)
     print('Missing GPS: %d' % (num_bad,))


### PR DESCRIPTION
- Fix flake8 errors in other/ibsfuncs.py

  ```
  wbia/other/ibsfuncs.py:885:13: F841 local variable 'ex' is assigned to but never used
  wbia/other/ibsfuncs.py:1672:5: E306 expected 1 blank line before a nested definition, found 0
  wbia/other/ibsfuncs.py:6642:15: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:6642:20: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:6642:25: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:7453:15: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:7453:20: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:7453:25: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:7531:15: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:7531:20: W605 invalid escape sequence '\ '
  wbia/other/ibsfuncs.py:7531:25: W605 invalid escape sequence '\ '
  ```

- Remove on_error= from vt.imread

  When running the `dev/reset_dbs.py` script:
  
  ```
  <!!! WARNING !!!>
  [!imread] [!?] Caught exception
  <class 'TypeError'>: _fix_orientation() got an unexpected keyword argument 'on_error'
  </!!! WARNING !!!>
  ```
  
  ```
  Traceback (most recent call last):
    File "dev/reset_dbs.py", line 14, in <module>
      reset_testdbs.reset_testdbs()
    File "/wbia/wildbook-ia/wbia/tests/reset_testdbs.py", line 180, in reset_testdbs
      ensure_smaller_testingdbs()
    File "/wbia/wildbook-ia/wbia/tests/reset_testdbs.py", line 153, in ensure_smaller_testingdbs
      make_testdb0()
    File "/wbia/wildbook-ia/wbia/tests/reset_testdbs.py", line 141, in make_testdb0
      aid = ibs.add_annots(gid_list, bbox_list=bbox_list)[0]
  IndexError: list index out of range
  ```
  
  It looks like `on_error` isn't a valid argument for `imread` from looking at
  wbia-vtool.

