### PR TITLE
Improve debugging support in dockerfiles and fix guitool doctest errors

### DIFF
--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update \
         tesseract-ocr-eng=4.00~git24-0e00fe6-1.2 \
         liblz4-dev=0.0~r131-2ubuntu3 \
         libhdf5-serial-dev=1.10.0-patch1+docs-4 \
+        xvfb=2:1.19.6-1ubuntu4 \
  && rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL https://get.docker.com -o get-docker.sh \

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -61,7 +61,7 @@ RUN . /virtualenv/env3/bin/activate \
  && pip install scikit-build
 
 # Build Python repositories with external codebases
-RUN . /virtualenv/env3/bin/activate \
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/flann \
  && /bin/bash run_developer_setup.sh \
  && cd /wbia/hesaff \
@@ -80,10 +80,10 @@ RUN . /virtualenv/env3/bin/activate \
  && cd /wbia/pyrf \
  && /bin/bash unix_build.sh \
  && cd /wbia/vtool \
- && /bin/bash run_developer_setup.sh
+ && /bin/bash run_developer_setup.sh'
 
 # Install Python repositories
-RUN . /virtualenv/env3/bin/activate \
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-cnn \
  && pip install -e . \
  && cd /wbia/hesaff \
@@ -111,4 +111,4 @@ RUN . /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-kaggle7 \
  && pip install -e . \
  && cd /wbia/wbia-plugin-2d-orientation \
- && pip install -e .
+ && pip install -e .'

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -19,7 +19,7 @@ RUN git clone --branch master https://github.com/WildbookOrg/wbia-tpl-brambox   
  && git clone --branch master https://github.com/WildbookOrg/wbia-plugin-finfindr       /wbia/wbia-plugin-finfindr \
  && git clone --branch master https://github.com/WildbookOrg/wbia-plugin-kaggle7        /wbia/wbia-plugin-kaggle7 \
  && git clone --branch master https://github.com/WildbookOrg/wbia-plugin-2d-orientation /wbia/wbia-plugin-2d-orientation \
- && git clone --branch master https://github.com/WildbookOrg/wildbook-ia              /wbia/wildbook-ia \
+ && git clone --branch develop https://github.com/WildbookOrg/wildbook-ia               /wbia/wildbook-ia \
  && git clone --branch master https://github.com/WildbookOrg/wbia-plugin-cnn            /wbia/wbia-plugin-cnn \
  && git clone --branch master https://github.com/WildbookOrg/wbia-tpl-lightnet          /wbia/lightnet \
  && git clone --branch master https://github.com/WildbookOrg/wbia-tpl-pydarknet         /wbia/pydarknet \

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -112,3 +112,8 @@ RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && pip install -e . \
  && cd /wbia/wbia-plugin-2d-orientation \
  && pip install -e .'
+
+# Set up xvfb for running gui doctests
+ENV DISPLAY :1
+
+CMD ["/bin/bash", "-c", "Xvfb :1 -screen 0 1024x768x16 &>/tmp/xvfb.log & /bin/bash"]

--- a/run_doctests.sh
+++ b/run_doctests.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+set -xe
+python dev/reset_dbs.py
 xdoctest wbia --style=google all

--- a/wbia/guitool/api_item_model.py
+++ b/wbia/guitool/api_item_model.py
@@ -1083,7 +1083,7 @@ def simple_thumbnail_widget():
 
     Example:
         >>> # ENABLE_DOCTEST
-        >>> import wbia.guitool
+        >>> import wbia.guitool as guitool
         >>> from wbia.guitool.api_item_model import *  # NOQA
         >>> guitool.ensure_qapp()  # must be ensured before any embeding
         >>> wgt = simple_thumbnail_widget()

--- a/wbia/guitool/api_item_model.py
+++ b/wbia/guitool/api_item_model.py
@@ -87,6 +87,7 @@ def updater(func):
     the middle of a layout changed
     """
     func_ = default_method_decorator(func)
+
     # @checks_qt_error
     @functools.wraps(func)
     def upd_wrapper(model, *args, **kwargs):
@@ -195,6 +196,7 @@ class APIItemModel(API_MODEL_BASE):
             assert len(model.ider_filters) == len(model.iders), 'bad filters'
             # ider_list =  [lambda: filtfn(ider()) for filtfn, ider in zip(model.ider_filters, model.iders)]
             # with ut.embed_on_exception_context:
+
             def wrap_ider(ider, filtfn):
                 def wrapped_ider(*args, **kwargs):
                     return filtfn(ider(*args, **kwargs))
@@ -1089,7 +1091,7 @@ def simple_thumbnail_widget():
         >>> wgt.show()
         >>> guitool.qtapp_loop(wgt, frequency=100, init_signals=True)
     """
-    import wbia.guitool
+    import wbia.guitool as guitool
 
     guitool.ensure_qapp()
     col_name_list = ['rowid', 'image_name', 'thumb']


### PR DESCRIPTION
- Use the develop branch of wildbook-ia in dockerfile

  I regularly build the wbia-provision with outdated wildbook-ia by
  mistake because it's using the `master` branch, while the latest changes
  are in the `develop` branch.  So I think it's better to use the
  `develop` branch in the dockerfile.  For production, it's probably best
  to use tags or what's released on pypi.

- Display command line being run in dockerfile

  We have some really long command lines in the dockerfiles and it's
  sometimes difficult to know exactly where something failed, for example:
  
  ```
  RUN . /virtualenv/env3/bin/activate \
   && cd /wbia/flann \
   && /bin/bash run_developer_setup.sh \
   && cd /wbia/hesaff \
   && /bin/bash run_developer_setup.sh \
   && cd /wbia/brambox \
   && /virtualenv/env3/bin/pip install -e . \
   && cd /wbia/lightnet \
   && /virtualenv/env3/bin/pip install -r requirements.txt \
   && /virtualenv/env3/bin/pip install -r develop.txt \
   && cd /wbia/wbia-plugin-flukematch \
   && /bin/bash unix_build.sh \
   && cd /wbia/wbia-plugin-curvrank \
   && /bin/bash unix_build.sh \
   && cd /wbia/pydarknet \
   && /bin/bash unix_build.sh \
   && cd /wbia/pyrf \
   && /bin/bash unix_build.sh \
   && cd /wbia/vtool \
   && /bin/bash run_developer_setup.sh
  ```
  
  In the middle of this I see something like:
  
  ```
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
  ImportError: No module named utool
  ```
  
  and with `/bin/bash -xc` around the whole command line, you get:
  
  ```
  + cd /wbia/pyrf
  + /bin/bash unix_build.sh
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
  ImportError: No module named utool
  ```

- Fix flake8 errors in guitool/app_item_model.py

  ```
  wbia/guitool/api_item_model.py:91:5: E306 expected 1 blank line before a nested definition, found 0
  wbia/guitool/api_item_model.py:198:13: E306 expected 1 blank line before a nested definition, found 0
  wbia/guitool/api_item_model.py:1092:5: F401 'wbia.guitool' imported but unused
  wbia/guitool/api_item_model.py:1094:5: F821 undefined name 'guitool'
  wbia/guitool/api_item_model.py:1124:11: F821 undefined name 'guitool'
  wbia/guitool/api_item_model.py:1139:11: F821 undefined name 'guitool'
  ```

- Fix guitool import in guitool/api_item_model.py doctests

  When running the wildbook-ia doctests:
  
  ```
  --- Error: 117 / 117 ---
      * REASON: NameError
      DOCTEST DEBUG INFO
        XDoc "/wbia/wildbook-ia/wbia/guitool/api_item_model.py::simple_thumbnail_widget:0", line 4 <- wrt doctest
        File "/wbia/wildbook-ia/wbia/guitool/api_item_model.py", line 1086, <- wrt source file
      DOCTEST PART BREAKDOWN
      Failed Part:
          1 >>> # ENABLE_DOCTEST
          2 >>> import wbia.guitool
          3 >>> from wbia.guitool.api_item_model import *  # NOQA
          4 >>> guitool.ensure_qapp()  # must be ensured before any embeding
          5 >>> wgt = simple_thumbnail_widget()
          6 >>> ut.quit_if_noshow()
          7 >>> wgt.show()
          8 >>> guitool.qtapp_loop(wgt, frequency=100, init_signals=True)
      DOCTEST TRACEBACK
      Traceback (most recent call last):
  
        File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 553, in run
          exec(code, test_globals)
  
        File "<doctest:/wbia/wildbook-ia/wbia/guitool/api_item_model.py::simple_thumbnail_widget:0>", line rel: 4, abs: 1086, in <module>
          >>> guitool.ensure_qapp()  # must be ensured before any embeding
  
      NameError: name 'guitool' is not defined
      DOCTEST REPRODUCTION
      CommandLine:
          python -m xdoctest /wbia/wildbook-ia/wbia/guitool/api_item_model.py simple_thumbnail_widget:0
  ```
  
  It's because we probably changed `import guitool` to
  `import wbia.guitool` and now `guitool` is not defined.  Changing to
  `import wbia.guitool as guitool` works.

- Install xvfb for running gui tests in docker files

  When running doctests in the docker container:
  
  ```
  DOCTEST STDOUT/STDERR
  [guitool] Init new QApplication
  QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
  qt.qpa.screen: QXcbConnection: Could not connect to display
  Could not connect to any X display.
  ```
  
  On a linux host, it's possible to do this:
  
  ```
  docker run --rm -ti -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix wildme/wbia-provision:latest /bin/bash
  ```
  
  in order to run the gui doctests.  It opens new windows on the host.
  
  If we don't care about the popups or if we're not using a linux host, we can
  install and configure xvfb so it's possible to run the gui tests inside the
  container.

- Run reset_dbs.py before running tests in run_doctests.sh

  It seems like `dev/reset_dbs.py` needs to run every time before tests
  are run, so just put it in `run_doctests.sh`.
