### PR TITLE
Fixes for doc tests in plottool/nx_helpers.py and dev.py

### DIFF
--- a/wbia/constants.py
+++ b/wbia/constants.py
@@ -132,12 +132,12 @@ SEX_TEXT_TO_INT = ut.invert_dict(SEX_INT_TO_TEXT)
 class PATH_NAMES(object):
     """ Path names for internal IBEIS database """
 
-    sqldb = '_wbia_database.sqlite3'
-    sqlstaging = '_wbia_staging.sqlite3'
+    sqldb = '_ibeis_database.sqlite3'
+    sqlstaging = '_ibeis_staging.sqlite3'
     _ibsdb = '_ibsdb'
-    cache = '_wbia_cache'
-    backups = '_wbia_backups'
-    logs = '_wbia_logs'
+    cache = '_ibeis_cache'
+    backups = '_ibeis_backups'
+    logs = '_ibeis_logs'
     chips = 'chips'
     figures = 'figures'
     flann = 'flann'
@@ -170,7 +170,7 @@ class REL_PATHS(object):
     trees = join(_ibsdb, PATH_NAMES.trees)
     nets = join(_ibsdb, PATH_NAMES.nets)
     uploads = join(_ibsdb, PATH_NAMES.uploads)
-    # All computed dirs live in <dbdir>/_ibsdb/_wbia_cache
+    # All computed dirs live in <dbdir>/_ibsdb/_ibeis_cache
     chips = join(cache, PATH_NAMES.chips)
     thumbs = join(cache, PATH_NAMES.thumbs)
     flann = join(cache, PATH_NAMES.flann)
@@ -186,8 +186,8 @@ EXCLUDE_COPY_REL_DIRS = [
     REL_PATHS.backups,
     REL_PATHS.figures,
     REL_PATHS.nets,
-    join(PATH_NAMES._ibsdb, '_wbia_cache*'),
-    #'_ibsdb/_wbia_cache',
+    join(PATH_NAMES._ibsdb, '_ibeis_cache*'),
+    #'_ibsdb/_ibeis_cache',
     '_ibsdb/chips',  # old path for caches
     './images',  # the hotspotter images dir
 ]

--- a/wbia/dbio/ingest_database.py
+++ b/wbia/dbio/ingest_database.py
@@ -174,7 +174,12 @@ class Ingestable2(object):
             """ lists images that are not in an internal cache """
             import utool as ut  # NOQA
 
-            ignore_list = ['_hsdb', '.hs_internals', '_wbia_cache', '_ibsdb']
+            ignore_list = [
+                '_hsdb',
+                '.hs_internals',
+                const.PATH_NAMES.cache,
+                const.PATH_NAMES._ibsdb,
+            ]
             gpath_list = ut.list_images(
                 img_dir, fullpath=True, recursive=True, ignore_list=ignore_list
             )
@@ -343,7 +348,12 @@ def ingest_rawdata(ibs, ingestable, localize=False):
         """ lists images that are not in an internal cache """
         import utool as ut  # NOQA
 
-        ignore_list = ['_hsdb', '.hs_internals', '_wbia_cache', '_ibsdb']
+        ignore_list = [
+            '_hsdb',
+            '.hs_internals',
+            const.PATH_NAMES.cache,
+            const.PATH_NAMES._ibsdb,
+        ]
         gpath_list = ut.list_images(
             img_dir, fullpath=True, recursive=True, ignore_list=ignore_list
         )

--- a/wbia/dev.py
+++ b/wbia/dev.py
@@ -162,15 +162,6 @@ def tune_flann(ibs, qaid_list, daid_list=None):
         python dev.py -t tune --db GZ_ALL
         python dev.py -t tune --db GIR_Tanya
         python dev.py -t tune --db PZ_Master0
-
-    Example:
-        >>> # ENABLE_DOCTEST
-        >>> from wbia._devscript import *  # NOQA
-        >>> # build test data
-        >>> # execute function
-        >>> result = func_wrapper()
-        >>> # verify results
-        >>> print(result)
     """
     all_aids = ibs.get_valid_aids()
     vecs = np.vstack(ibs.get_annot_vecs(all_aids))

--- a/wbia/dev.py
+++ b/wbia/dev.py
@@ -36,7 +36,6 @@ CommandLine:
 """
 # TODO: ADD COPYRIGHT TAG
 from __future__ import absolute_import, division, print_function
-import multiprocessing
 import sys
 import numpy as np
 from wbia._devscript import devcmd, DEVCMD_FUNCTIONS, DEVPRECMD_FUNCTIONS
@@ -48,6 +47,7 @@ import utool
 import wbia.plottool as pt
 import wbia
 
+# import multiprocessing
 # if __name__ == '__main__':
 #     multiprocessing.freeze_support()
 #     wbia._preload()
@@ -59,7 +59,7 @@ from wbia.plottool import draw_func2 as df2  # NOQA
 from wbia import sysres  # NOQA
 from wbia.other import ibsfuncs  # NOQA
 from wbia.dbio import ingest_hsdb  # NOQA
-from wbia._devcmds_wbia import (
+from wbia._devcmds_wbia import (  # NOQA
     GZ_VIEWPOINT_EXPORT_PAIRS,
     MOTHERS_VIEWPOINT_EXPORT_PAIRS,
     change_names,
@@ -78,13 +78,14 @@ from wbia._devcmds_wbia import (
     show_aids,
     sver_aids,
     vdd,
-)  # NOQA
+)
 
 # IBEIS
 from wbia.init import main_helpers  # NOQA
 from wbia.other import dbinfo  # NOQA
 from wbia.expt import experiment_configs  # NOQA
 from wbia.expt import harness  # NOQA
+from wbia.expt.experiment_drawing import draw_annot_scoresep
 from wbia import params  # NOQA
 
 print, rrr, profile = utool.inject2(__name__)

--- a/wbia/plottool/nx_helpers.py
+++ b/wbia/plottool/nx_helpers.py
@@ -1705,7 +1705,7 @@ def draw_network2(
                     strokekw['linewidth'] = full_lw
                     path_effects += [patheffects.withStroke(**strokekw)]
 
-            ## http://matplotlib.org/1.2.1/examples/api/clippath_demo.html
+            # http://matplotlib.org/1.2.1/examples/api/clippath_demo.html
             if data.get('shadow', None) is not None:
                 shadowkw = data['shadow']
                 if shadowkw is not False:

--- a/wbia/plottool/nx_helpers.py
+++ b/wbia/plottool/nx_helpers.py
@@ -154,7 +154,7 @@ def show_nx(
     if kwargs.get('modify_ax', True):
         ax.grid(False)
         pt.plt.axis('equal')
-        ax.axesPatch.set_facecolor('white')
+        ax.patch.set_facecolor('white')
         ax.autoscale()
         ax.autoscale_view(True, True, True)
     # axes.facecolor


### PR DESCRIPTION
- Fix flake8 errors in plottool/nx_helpers.py

  ```
  wbia/plottool/nx_helpers.py:1708:13: E266 too many leading '#' for block comment
  ```

- Fix Matplotlib axes deprecated `.axesPatch` to `.patch`

  When running doctests:
  
  ```
  DOCTEST TRACEBACK
  Traceback (most recent call last):
  
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 553, in run
      exec(code, test_globals)
  
    File "<doctest:/wbia/wildbook-ia/wbia/plottool/nx_helpers.py::show_nx:0>", line rel: 15, abs: 124, in <module>
      >>> e = show_nx(graph, with_labels, fnum, pnum, layout='agraph')
  
    File "/wbia/wildbook-ia/wbia/plottool/nx_helpers.py", line 157, in show_nx
      ax.axesPatch.set_facecolor('white')
  
  AttributeError: 'AxesSubplot' object has no attribute 'axesPatch'
  DOCTEST REPRODUCTION
  CommandLine:
      python -m xdoctest /wbia/wildbook-ia/wbia/plottool/nx_helpers.py show_nx:0
  ```
  
  According to https://github.com/matplotlib/basemap/pull/373:
  
  > With the release of Matplotlib 2.1.0, Axes.axesPatch has been
  > deprecated in favor of Axes.patch.
  
  Changing `.axesPatch` to `.patch` fixed this error.

- Fix flake8 errors in wbia/dev.py

  ```
  wbia/dev.py:39:1: F401 'multiprocessing' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.GZ_VIEWPOINT_EXPORT_PAIRS' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.MOTHERS_VIEWPOINT_EXPORT_PAIRS' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.change_names' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.convert_hsdbs' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.delete_all_chips' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.delete_all_feats' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.delete_cache' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.ensure_mtest' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.ensure_nauts' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.ensure_wilddogs' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.export' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.list_dbs' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.list_unconverted_hsdbs' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.openworkdirs_test' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.query_aids' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.show_aids' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.sver_aids' imported but unused
  wbia/dev.py:62:1: F401 'wbia._devcmds_wbia.vdd' imported but unused
  wbia/dev.py:260:9: F821 undefined name 'draw_annot_scoresep'
  ```

- Delete dev.py broken tune_flann doctest

  The doc test looks like this:
  
  ```
  >>> from wbia._devscript import *  # NOQA
  >>> # build test data
  >>> # execute function
  >>> result = func_wrapper()
  >>> # verify results
  >>> print(result)
  ```
  
  `wbia._devscript` doesn't have an importable `func_wrapper` function, all of
  the `func_wrapper` functions are inside top level functions.  I went back to
  the commit (213fede578) when this doctest was added and still couldn't find how
  this test could possibly work.  On top of that, this doc test doesn't call
  `tune_flann`.  I think it's ok to remove this.

- Change some path related constants from "wbia" to "ibeis"

  This is used in tests and we download zips with those specified paths so
  we need to change the constants back to "ibeis" for the tests to run.
