### PR TITLE
Update super_setup with specific repository names

### DIFF
--- a/super_setup.py
+++ b/super_setup.py
@@ -1,15 +1,15 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Requirements:
     pip install gitpython click ubelt
 """
 import re
+import functools
 from os.path import exists
 from os.path import join
 from os.path import dirname
 from os.path import abspath
-import functools
 
 import click
 import ubelt as ub
@@ -696,135 +696,20 @@ def determine_code_dpath():
     return code_dpath
 
 
-def make_netharn_registry(remote):
+def make_netharn_registry():
     code_dpath = determine_code_dpath()
-    CommonRepo = functools.partial(Repo, code_dpath=code_dpath)
+    repo_factory = functools.partial(Repo, code_dpath=code_dpath)
+    gen_github_remote = lambda r: "git@github.com:{}".format(r)
     repos = [
-        # The util libs
-        CommonRepo(
-            name='utool',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Erotemic': 'git@github.com:Erotemic/utool.git',
-                'Wildbook': 'git@github.com:WildbookOrg/utool.git',
-            },
-        ),
-        CommonRepo(
-            name='ubelt',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Erotemic': 'git@github.com:Erotemic/ubelt.git',
-                'Wildbook': 'git@github.com:WildbookOrg/ubelt.git',
-            },
-        ),
-        CommonRepo(
-            name='vtool_ibeis',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Erotemic': 'git@github.com:Erotemic/vtool_ibeis.git',
-                'Wildbook': 'git@github.com:WildbookOrg/wbia-vtool.git',
-            },
-        ),
-        CommonRepo(
-            name='pyflann_ibeis',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Erotemic': 'git@github.com:Erotemic/pyflann_ibeis.git',
-                'Wildbook': 'git@github.com:WildbookOrg/pyflann_ibeis.git',
-            },
-        ),
-        CommonRepo(
-            name='pyhesaff',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Erotemic': 'git@github.com:Erotemic/pyhesaff.git',
-                'Wildbook': 'git@github.com:WildbookOrg/pyhesaff.git',
-            },
-        ),
-        CommonRepo(
-            name='pydarknet',
-            branch='master',
-            remote=remote,
-            remotes={'Wildbook': 'git@github.com:WildbookOrg/pydarknet.git',},
-        ),
-        CommonRepo(
-            name='pyrf',
-            branch='master',
-            remote=remote,
-            remotes={'Wildbook': 'git@github.com:WildbookOrg/pyrf.git',},
-        ),
-        CommonRepo(
-            name='wbia',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Erotemic': 'git@github.com:Erotemic/wbia.git',
-                'Wildbook': 'git@github.com:WildbookOrg/wbia.git',
-            },
-        ),
-        CommonRepo(
-            name='wbia_cnn',
-            branch='master',
-            remote=remote,
-            remotes={'Wildbook': 'git@github.com:WildbookOrg/wbia_cnn.git',},
-        ),
-        CommonRepo(
-            name='ibeis_curvrank',
-            branch='master',
-            remote=remote,
-            remotes={'Wildbook': 'git@github.com:WildbookOrg/ibeis-curvrank-module.git',},
-        ),
-        CommonRepo(
-            name='wbia_deepsense',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Wildbook': 'git@github.com:WildbookOrg/ibeis-deepsense-module.git',
-            },
-        ),
-        CommonRepo(
-            name='wbia_finfindr',
-            branch='master',
-            remote=remote,
-            remotes={'Wildbook': 'git@github.com:WildbookOrg/ibeis-finfindr-module.git',},
-        ),
-        CommonRepo(
-            name='ibeis_flukematch',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Wildbook': 'git@github.com:WildbookOrg/ibeis-flukematch-module.git',
-            },
-        ),
-        CommonRepo(
-            name='wbia_kaggle7',
-            branch='master',
-            remote=remote,
-            remotes={'Wildbook': 'git@github.com:WildbookOrg/ibeis-kaggle7-module.git',},
-        ),
-        CommonRepo(
-            name='wbia_2d_orientation',
-            branch='master',
-            remote=remote,
-            remotes={
-                'Wildbook': 'git@github.com:WildbookOrg/wbia-2d-orientation-module.git',
-            },
-        ),
+        repo_factory(name=name, branch=branch, remote=gen_github_remote(repo))
+        for repo, name, branch in REPOS
     ]
     registery = RepoRegistry(repos)
     return registery
 
 
 def main():
-    REMOTE = 'Erotemic'
-    REMOTE = 'Wildbook'
-
-    registery = make_netharn_registry(remote=REMOTE)
+    registery = make_netharn_registry()
 
     only = ub.argval('--only', default=None)
     if only is not None:

--- a/super_setup.py
+++ b/super_setup.py
@@ -9,8 +9,10 @@ from os.path import exists
 from os.path import join
 from os.path import dirname
 from os.path import abspath
-import ubelt as ub
 import functools
+
+import click
+import ubelt as ub
 
 
 class ShellException(Exception):
@@ -25,32 +27,6 @@ class DirtyRepoError(Exception):
     automated scripts. To be safe, we don't do anything. We ensure this by
     raising this error.
     """
-
-
-def parse_version(package):
-    """
-    Statically parse the version number from __init__.py
-
-    CommandLine:
-        python -c "import setup; print(setup.parse_version('ovharn'))"
-    """
-    from os.path import dirname, join
-    import ast
-
-    init_fpath = join(dirname(__file__), package, '__init__.py')
-    with open(init_fpath) as file_:
-        sourcecode = file_.read()
-    pt = ast.parse(sourcecode)
-
-    class VersionVisitor(ast.NodeVisitor):
-        def visit_Assign(self, node):
-            for target in node.targets:
-                if target.id == '__version__':
-                    self.version = node.value.s
-
-    visitor = VersionVisitor()
-    visitor.visit(pt)
-    return visitor.version
 
 
 class GitURL(object):
@@ -379,6 +355,9 @@ class Repo(ub.NiceRepr):
         """
         Print current version information
         """
+        # FIXME (7-Jul-12020) temporary disabled until versions have been stablized
+        raise NotImplementedError()
+
         fmtkw = {}
         fmtkw['pkg'] = parse_version(repo.pkg_dpath) + ','
         fmtkw['sha1'] = repo._cmd('git rev-parse HEAD', verbose=0)['out'].strip()
@@ -824,8 +803,6 @@ def main():
     REMOTE = 'Erotemic'
     REMOTE = 'Wildbook'
 
-    import click
-
     registery = make_netharn_registry(remote=REMOTE)
 
     only = ub.argval('--only', default=None)
@@ -900,10 +877,10 @@ def main():
     def doctest():
         registery.apply('doctest')
 
-    @cli_group.add_command
-    @click.command('versions', context_settings=default_context_settings)
-    def versions():
-        registery.apply('versions')
+    # FIXME (7-Jul-12020) disabled until versioning code has stablized.
+    # @cli.command('versions', context_settings=default_context_settings)
+    # def versions():
+    #     registery.apply('versions')
 
     cli_group()
 

--- a/super_setup.py
+++ b/super_setup.py
@@ -15,6 +15,27 @@ import click
 import ubelt as ub
 
 
+REPOS = [
+    # (<repo-on-github>, <checkout-name>, <branch>)
+    ('WildbookOrg/wbia-tpl-brambox', 'wbia-tpl-brambox', 'master'),
+    ('WildbookOrg/wbia-tpl-pyflann', 'wbia-tpl-pyflann', 'master'),
+    ('WildbookOrg/wbia-tpl-pyhesaff', 'wbia-tpl-pyhesaff', 'master'),
+    ('WildbookOrg/wildbook-ia', 'wildbook-ia', 'develop'),
+    ('WildbookOrg/wbia-tpl-lightnet', 'wbia-tpl-lightnet', 'master'),
+    ('WildbookOrg/wbia-tpl-pydarknet', 'wbia-tpl-pydarknet', 'master'),
+    ('WildbookOrg/wbia-tpl-pyrf', 'wbia-tpl-pyrf', 'master'),
+    ('WildbookOrg/wbia-utool', 'wbia-utool', 'master'),
+    ('WildbookOrg/wbia-vtool', 'wbia-vtool', 'master'),
+    ('WildbookOrg/wbia-plugin-cnn', 'wbia-plugin-cnn', 'master'),
+    ('WildbookOrg/wbia-plugin-flukematch', 'wbia-plugin-flukematch', 'master'),
+    ('WildbookOrg/wbia-plugin-curvrank', 'wbia-plugin-curvrank', 'master'),
+    ('WildbookOrg/wbia-plugin-deepsense', 'wbia-plugin-deepsense', 'master'),
+    ('WildbookOrg/wbia-plugin-finfindr', 'wbia-plugin-finfindr', 'master'),
+    ('WildbookOrg/wbia-plugin-kaggle7', 'wbia-plugin-kaggle7', 'master'),
+    ('WildbookOrg/wbia-plugin-2d-orientation', 'wbia-plugin-2d-orientation', 'master'),
+]
+
+
 class ShellException(Exception):
     """
     Raised when shell returns a non-zero error code
@@ -833,47 +854,40 @@ def main():
     }
 
     @click.group(context_settings=default_context_settings)
-    def cli_group():
+    def cli():
         pass
 
-    @cli_group.add_command
-    @click.command('pull', context_settings=default_context_settings)
+    @cli.command('pull', context_settings=default_context_settings)
     def pull():
         registery.apply('pull', num_workers=num_workers)
 
-    @cli_group.add_command
-    @click.command('ensure', context_settings=default_context_settings)
+    @cli.command('ensure', context_settings=default_context_settings)
     def ensure():
         """
         Ensure is the live run of "check".
         """
         registery.apply('ensure', num_workers=num_workers)
 
-    @cli_group.add_command
-    @click.command('ensure_clone', context_settings=default_context_settings)
+    @cli.command('ensure_clone', context_settings=default_context_settings)
     def ensure_clone():
         registery.apply('ensure_clone', num_workers=num_workers)
 
-    @cli_group.add_command
-    @click.command('check', context_settings=default_context_settings)
+    @cli.command('check', context_settings=default_context_settings)
     def check():
         """
         Check is just a dry run of "ensure".
         """
         registery.apply('check', num_workers=num_workers)
 
-    @cli_group.add_command
-    @click.command('status', context_settings=default_context_settings)
+    @cli.command('status', context_settings=default_context_settings)
     def status():
         registery.apply('status', num_workers=num_workers)
 
-    @cli_group.add_command
-    @click.command('develop', context_settings=default_context_settings)
+    @cli.command('develop', context_settings=default_context_settings)
     def develop():
         registery.apply('develop', num_workers=0)
 
-    @cli_group.add_command
-    @click.command('doctest', context_settings=default_context_settings)
+    @cli.command('doctest', context_settings=default_context_settings)
     def doctest():
         registery.apply('doctest')
 
@@ -882,7 +896,7 @@ def main():
     # def versions():
     #     registery.apply('versions')
 
-    cli_group()
+    cli()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a simple set of adjustments to bring this script into a usable state. I've not changed the core logic, except to disable the versions command, since the code assumes a static version. I've disabled it rather than updating it because it's not of particular use at the moment. Later when and if needed we can update it and bring it back into existence.

I've primarily focused on getting the `pull` and `ensure` commands working without extra remote name overhead. These two commands are all I need at the moment. I'll do a followup PR if the other commands become useful.