### PR TITLE
Nightly image building workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,32 @@
+name: Nightly
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
+  pull_request:
+    paths:
+      - '.github/workflows/nightly-container-build.yml'
+      - 'devops/**'
+
+jobs:
+  devops:
+    name: DevOps container image build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Build containers
+      - name: Build containers
+        run: bash devops/build.sh
+
+      # Log into container registries
+      - name: Log into Docker Hub
+        run: echo "${{ secrets.WBIA_WILDMEBOT_DOCKER_HUB_TOKEN }}" | docker login -u wildmebot --password-stdin
+      - name: Log into GitHub Packages
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      # Push containers out to container registries
+      - name: Push to GitHub Packages
+        run: bash devops/publish.sh -t nightly -r docker.pkg.github.com
+      - name: Push to Docker Hub
+        run: bash devops/publish.sh -t nightly

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,6 +1,6 @@
 # Containerized Wildbook-IA Installation
 
-This directory contains the containerized build instructions (docker build files) for creating images for the Wildbook IA application. The build is divided into four distinct stages: base, dependencies, provision and wbia. These each correspond to the final image name within the container registry (i.e. Docker Hub) as: wildme/wbia-base, wildme/wbia-dependencies, wildme/wbia-provision and wildme/wbia.
+This directory contains the containerized build instructions (docker build files) for creating images for the Wildbook IA application. The build is divided into four distinct stages: base, dependencies, provision and wbia. These each correspond to the final image name within the container registry (i.e. Docker Hub) as: [wildme/wbia-base](https://hub.docker.com/r/wildme/wbia-base), [wildme/wbia-dependencies](https://hub.docker.com/r/wildme/wbia-dependencies), [wildme/wbia-provision](https://hub.docker.com/r/wildme/wbia-provision) and [wildme/wbia](https://hub.docker.com/r/wildme/wbia).
 
 ## Build instructions
 

--- a/devops/README.md
+++ b/devops/README.md
@@ -10,3 +10,12 @@ To build the images run:
 This will build the four stage images.
 
 It is not recommended that you upload these images to the container registry. Please leave that to the continuous integration (CI) service.
+
+## Publish instructions
+
+To publish the results use:
+    ./publish.sh
+
+This will publish the four build images to [Docker Hub](https://hub.docker.com) by default. You can change the container registry to publish to using the `-r` option. See `./publish.sh -h` for usage details.
+
+Do not run this locally, leave that to the continuous integration (CI) service. See the Nightly workflow in `.github/workflows/nightly.yml` for more information.

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,6 +1,6 @@
-# Containerized IBEIS Installation
+# Containerized Wildbook-IA Installation
 
-This directory contains the containerized build instructions (docker build files) for creating images for the IBEIS application. The build is divided into four distinct stages: base, dependencies, provision and wbia. These each correspond to the final image name within the container registry (i.e. Docker Hub) as: wildme/wbia-base, wildme/wbia-dependencies, wildme/wbia-provision and wildme/wbia.
+This directory contains the containerized build instructions (docker build files) for creating images for the Wildbook IA application. The build is divided into four distinct stages: base, dependencies, provision and wbia. These each correspond to the final image name within the container registry (i.e. Docker Hub) as: wildme/wbia-base, wildme/wbia-dependencies, wildme/wbia-provision and wildme/wbia.
 
 ## Build instructions
 

--- a/devops/build.sh
+++ b/devops/build.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
-cd base && docker build -t wildme/wbia-base:latest .
-cd ..
-cd dependencies && docker build -t wildme/wbia-dependencies:latest .
-cd ..
-cd provision && docker build -t wildme/wbia-provision:latest .
-cd ..
+set -ex
+
+# See https://stackoverflow.com/a/246128/176882
+export ROOT_LOC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Change to the script's root directory location
+cd ${ROOT_LOC}
+
+# Build the images in dependence order
+docker build -t wildme/wbia-base:latest base
+docker build -t wildme/wbia-dependencies:latest dependencies
+docker build -t wildme/wbia-provision:latest provision
 docker build -t wildme/wbia:latest .

--- a/devops/publish.sh
+++ b/devops/publish.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+usage () {
+    echo "Usage: $0 [-t <tag>] [-r <registry-url>]";
+}
+
+# Parse commandline options
+while getopts ":t:r:" option; do
+    case ${option} in
+        t ) TAG=${OPTARG};;
+        r ) REGISTRY=${OPTARG};;
+        \? ) usage; exit 1;;
+    esac
+done
+
+# Assign variables
+TAG=${TAG:-latest}
+REGISTRY=${REGISTRY:-}
+# Set the image prefix
+if [ -n "$REGISTRY" ]; then
+    IMG_PREFIX="${REGISTRY}/WildbookOrg/wildbook-ia/"
+else
+    IMG_PREFIX="wildme/"
+fi
+
+# Tag built images from `build.sh`, which tags as `latest`
+for IMG in wbia-base wbia-dependencies wbia-provision wbia; do
+    echo "Tagging wildme/${IMG}:latest --> ${IMG_PREFIX}${IMG}:${TAG}"
+    docker tag wildme/${IMG}:latest ${IMG_PREFIX}${IMG}:${TAG}
+    echo "Pushing ${IMG_PREFIX}${IMG}:${TAG}"
+    docker push ${IMG_PREFIX}${IMG}:${TAG}
+done


### PR DESCRIPTION
Provides a workflow for building an application image on a nightly basis. This publishes the results both to github packages and docker hub.