### PR TITLE
Build each package in an individual layer

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Push to GitHub Packages
         run: bash devops/publish.sh -t nightly -r docker.pkg.github.com
       - name: Push to Docker Hub
+        if: github.event_name == 'schedule'
         run: bash devops/publish.sh -t nightly

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -63,53 +63,74 @@ RUN . /virtualenv/env3/bin/activate \
 # Build Python repositories with external codebases
 RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/flann \
- && /bin/bash run_developer_setup.sh \
+ && /bin/bash run_developer_setup.sh'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/hesaff \
- && /bin/bash run_developer_setup.sh \
+ && /bin/bash run_developer_setup.sh'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/brambox \
- && /virtualenv/env3/bin/pip install -e . \
+ && /virtualenv/env3/bin/pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/lightnet \
  && /virtualenv/env3/bin/pip install -r requirements.txt \
- && /virtualenv/env3/bin/pip install -r develop.txt \
+ && /virtualenv/env3/bin/pip install -r develop.txt'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-flukematch \
- && /bin/bash unix_build.sh \
+ && /bin/bash unix_build.sh'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-curvrank \
- && /bin/bash unix_build.sh \
+ && /bin/bash unix_build.sh'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/pyrf \
- && /bin/bash unix_build.sh \
+ && /bin/bash unix_build.sh'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/vtool \
  && /bin/bash run_developer_setup.sh'
 
 # Install Python repositories
 RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-cnn \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/hesaff \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/lightnet \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/pydarknet \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/pyrf \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/utool \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/vtool \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/pydarknet \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wildbook-ia \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-flukematch \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-curvrank \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-deepsense \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-finfindr \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-kaggle7 \
- && pip install -e . \
+ && pip install -e .'
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wbia-plugin-2d-orientation \
  && pip install -e .'
 

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -110,9 +110,6 @@ RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/vtool \
  && pip install -e .'
 RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
- && cd /wbia/pydarknet \
- && pip install -e .'
-RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/wildbook-ia \
  && pip install -e .'
 RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \


### PR DESCRIPTION
*  Build each package in an individual layer. Creating many layers isn't going to hurt in this case. It's not the number of layers that is a problem, but the amount of stuff in a layer. As such, this does not create any additional stuff, but just more layers. This then gives the developer the ability to fail and continue from that point rather than fail and rebuild everything before it.

* Fixes a duplicate build instruction for the installation of pydarknet.

* Only publishes to Docker Hub during the scheduled nightly build. This prevents the publication of the image to Docker Hub when a pull request is made. The images will still be available in GitHub packages though.