### PR TITLE
Correct github package's docker image name for the nightly image

### DIFF
--- a/devops/publish.sh
+++ b/devops/publish.sh
@@ -20,7 +20,7 @@ TAG=${TAG:-latest}
 REGISTRY=${REGISTRY:-}
 # Set the image prefix
 if [ -n "$REGISTRY" ]; then
-    IMG_PREFIX="${REGISTRY}/WildbookOrg/wildbook-ia/"
+    IMG_PREFIX="${REGISTRY}/wildbookorg/wildbook-ia/"
 else
     IMG_PREFIX="wildme/"
 fi


### PR DESCRIPTION
Apparently the image name will need to be lowercase given the
following error.
```
Run bash devops/publish.sh -t nightly -r docker.pkg.github.com
  bash devops/publish.sh -t nightly -r docker.pkg.github.com
  shell: /bin/bash -e {0}
Tagging wildme/wbia-base:latest --> docker.pkg.github.com/WildbookOrg/wildbook-ia/wbia-base:nightly
Error parsing reference: "docker.pkg.github.com/WildbookOrg/wildbook-ia/wbia-base:nightly" is not a valid repository/tag: invalid reference format: repository name must be lowercase
```