### PR TITLE
Fix GUI entrypoint

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -36,6 +36,7 @@ setuptools>=34.1.0
 simplejson>=3.6.5
 six>=1.10.0
 statsmodels>=0.6.1
+tqdm
 
 torch
 torchvision

--- a/wbia/main_module.py
+++ b/wbia/main_module.py
@@ -68,7 +68,7 @@ def _init_matplotlib():
 
 
 def _init_gui(activate=True):
-    import wbia.guitool
+    from wbia import guitool
 
     if NOT_QUIET:
         print('[main] _init_gui()')
@@ -195,7 +195,7 @@ def _init_numpy():
 
 
 def _guitool_loop(main_locals, ipy=False):
-    import wbia.guitool
+    from wbia import guitool
     from wbia import params
 
     print('[main] guitool loop')


### PR DESCRIPTION
This set of changes adds a missing package requirement, `tqdm`. More importantly it fixes the entrypoint for running the GUI application (e.g. via `_dev/main.py --gui`).