### PR TITLE
Fix imports in wbia/unstable/bayes.py and demobayes.py

### DIFF
--- a/wbia/unstable/bayes.py
+++ b/wbia/unstable/bayes.py
@@ -161,7 +161,7 @@ def make_name_model(
 
     # Match Factor
     def match_pmf(match_type, n1, n2):
-        return {True: {'same': 1.0, 'diff': 0.0}, False: {'same': 0.0, 'diff': 1.0},}[
+        return {True: {'same': 1.0, 'diff': 0.0}, False: {'same': 0.0, 'diff': 1.0}}[
             n1 == n2
         ][match_type]
 
@@ -760,6 +760,7 @@ def draw_tree_model(model, **kwargs):
         fig = pt.figure(fnum=fnum, doclf=True)  # NOQA
         ax = pt.gca()
         netx_graph = model.to_junction_tree()
+
         # prettify nodes
         def fixtupkeys(dict_):
             return {

--- a/wbia/unstable/bayes.py
+++ b/wbia/unstable/bayes.py
@@ -12,7 +12,7 @@ import six  # NOQA
 import utool as ut
 import numpy as np
 from six.moves import zip
-from wbia.algo.hots import pgm_ext
+from wbia.unstable import pgm_ext
 
 print, rrr, profile = ut.inject2(__name__)
 

--- a/wbia/unstable/demobayes.py
+++ b/wbia/unstable/demobayes.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import six  # NOQA
 import utool as ut
 import numpy as np
-from wbia.algo.hots.bayes import make_name_model, temp_model, draw_tree_model
+from wbia.unstable.bayes import make_name_model, temp_model, draw_tree_model
 
 print, rrr, profile = ut.inject2(__name__)
 

--- a/wbia/unstable/pgm_ext.py
+++ b/wbia/unstable/pgm_ext.py
@@ -4,7 +4,7 @@ import six  # NOQA
 import utool as ut
 import numpy as np
 from six.moves import zip, map
-from wbia.algo.hots import pgm_viz
+from wbia.unstable import pgm_viz
 
 try:
     import pgmpy


### PR DESCRIPTION
- Fix flake8 errors in wbia/unstable/bayes.py

  ```
  wbia/unstable/bayes.py:164:84: E231 missing whitespace after ','
  wbia/unstable/bayes.py:764:9: E306 expected 1 blank line before a nested definition, found 0
  ```

- Fix imports in wbia/unstable/bayes.py and pgm_ext.py

  When running tests:
  
  ```
  _____________________________________________________ ERROR collecting wbia/unstable/bayes.py _____________________________________________________
  ImportError while importing test module '/wbia/wildbook-ia/wbia/unstable/bayes.py'.
  Hint: make sure your test modules/packages have valid Python names.
  Traceback:
  wbia/unstable/bayes.py:15: in <module>
      from wbia.algo.hots import pgm_ext
  E   ImportError: cannot import name 'pgm_ext'
  ```
  
  ```
  _____________________________________________________ ERROR collecting wbia/unstable/bayes.py _____________________________________________________
  ImportError while importing test module '/wbia/wildbook-ia/wbia/unstable/bayes.py'.
  Hint: make sure your test modules/packages have valid Python names.
  Traceback:
  wbia/unstable/bayes.py:15: in <module>
      from wbia.unstable import pgm_ext
  wbia/unstable/pgm_ext.py:7: in <module>
      from wbia.algo.hots import pgm_viz
  E   ImportError: cannot import name 'pgm_viz'
  ```
  
  The `pgm_ext` and `pgm_viz` modules are in `wbia/unstable`.

- Fix imports in wbia/unstable/demobayes.py

  When running `pytest`:
  
  ```
  ___________________________________________________ ERROR collecting wbia/unstable/demobayes.py ___________________________________________________
  ImportError while importing test module '/wbia/wildbook-ia/wbia/unstable/demobayes.py'.
  Hint: make sure your test modules/packages have valid Python names.
  Traceback:
  wbia/unstable/demobayes.py:6: in <module>
      from wbia.algo.hots.bayes import make_name_model, temp_model, draw_tree_model
  E   ModuleNotFoundError: No module named 'wbia.algo.hots.bayes'
  ```
  
  `bayes.py` is in `wbia/unstable`.

----------------

Towards #51 

The `wbia/unstable/bayes.py` test still fails but I don't know how to fix it:

```
==================================================================== FAILURES =====================================================================
_________________________________________________________ [xdoctest] reduce_marginalize:0 _________________________________________________________
* REASON: NameError
DOCTEST DEBUG INFO
  XDoc "/wbia/wildbook-ia/wbia/unstable/bayes.py::reduce_marginalize:0", line 1 <- wrt doctest
  File "/wbia/wildbook-ia/wbia/unstable/bayes.py", line 314, <- wrt source file
DOCTEST PART BREAKDOWN
Failed Part:
    1 >>> reduced_joint = joint.observe(
    2 >>>     query_variables, evidence, inplace=False)
    3 >>> new_rows = reduced_joint._row_labels()
    4 >>> new_vals = reduced_joint.values.ravel()
    5 >>> map_vals = new_rows[new_vals.argmax()]
    6 >>> map_assign = dict(zip(reduced_joint.variables, map_vals))
DOCTEST TRACEBACK
Traceback (most recent call last):

  File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 553, in run
    exec(code, test_globals)

  File "<doctest:/wbia/wildbook-ia/wbia/unstable/bayes.py::reduce_marginalize:0>", line rel: 1, abs: 314, in <module>
    >>> reduced_joint = joint.observe(

NameError: name 'joint' is not defined
DOCTEST REPRODUCTION
CommandLine:
    pytest /wbia/wildbook-ia/wbia/unstable/bayes.py::reduce_marginalize:0
/wbia/wildbook-ia/wbia/unstable/bayes.py:314: NameError
```