### PR TITLE
Add missing docker requirement

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -5,6 +5,7 @@ colorama>=0.3.2
 dateutils>=0.6.6
 
 delorean
+docker
 flask>=0.10.1
 
 futures>=3.2.0;python_version<="2.7"


### PR DESCRIPTION
The deepsense code requires access to the docker api.