### PR TITLE
Fix TypeError in algo/hots/neighbor_index_cache.py

### DIFF
--- a/wbia/algo/hots/neighbor_index_cache.py
+++ b/wbia/algo/hots/neighbor_index_cache.py
@@ -487,8 +487,7 @@ def request_memcached_wbia_nnindexer(
     if (
         not force_rebuild
         and use_memcache
-        and nnindex_cfgstr
-        in NEIGHBOR_CACHE.has_key()  # NOQA (has_key is for a lru cache)
+        and NEIGHBOR_CACHE.has_key(nnindex_cfgstr)  # NOQA (has_key is for a lru cache)
     ):
         if veryverbose or ut.VERYVERBOSE or ut.VERBOSE:
             print('... nnindex memcache hit: cfgstr=%s' % (nnindex_cfgstr,))


### PR DESCRIPTION
When running test
`wbia/viz/interact/interact_matches.py::testdata_match_interact:0`:

```
  File "/wbia/wildbook-ia/wbia/algo/hots/neighbor_index_cache.py", line 491, in request_memcached_wbia_nnindexer
    in NEIGHBOR_CACHE.has_key()  # NOQA (has_key is for a lru cache)

TypeError: has_key() missing 1 required positional argument: 'item'
```

Looking back at recent changes to the file.  There was this commit 4e8f49c92c,
"Fixed vast array of linting errors".  The relevant bit for
`wbia/algo/hots/neighbor_index_cache.py`:

```
-        not force_rebuild and use_memcache and NEIGHBOR_CACHE.has_key(nnindex_cfgstr)
-    ):  # NOQA (has_key is for a lru cache)
+        not force_rebuild
+        and use_memcache
+        and nnindex_cfgstr
+        in NEIGHBOR_CACHE.has_key()  # NOQA (has_key is for a lru cache)
+    ):
```

It looks like we made a mistake while trying to fix some linting errors.  I'm
changing it back to:

```
+        not force_rebuild
+        and use_memcache
+        and NEIGHBOR_CACHE.has_key(nnindex_cfgstr)  # NOQA (has_key is for a lru cache)
```

---

Towards #51