### PR TITLE
Rename the outward facing distribution name from wbia to wildbook-ia

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,7 @@ def autogen_explicit_imports():
     controller_inject.dev_autogen_explicit_injects()
 
 
-NAME = 'wbia'
+NAME = 'wildbook-ia'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is with the expectation of being able to do the following:

    pip install wildbook-ia

as opposed to:

    pip install wbia

where the former is more human readable and intuitively does what you'd expect, install the Wildbook IA application rather than a library like thing called wbia.

