### PR TITLE
Revert ibeis->wbia filename changes for backwards compatibility

### DIFF
--- a/wbia/dbio/export_hsdb.py
+++ b/wbia/dbio/export_hsdb.py
@@ -179,9 +179,9 @@ def export_wbia_to_hotspotter(ibs):
 def dump_hots_tables(ibs):
     """ Dumps hotspotter like tables to disk """
     ibsdir = ibs.get_ibsdir()
-    gtbl_name = join(ibsdir, 'images_table.csv')
-    ntbl_name = join(ibsdir, 'names_table.csv')
-    rtbl_name = join(ibsdir, 'annotations_table.csv')
+    gtbl_name = join(ibsdir, 'IBEIS_DUMP_images_table.csv')
+    ntbl_name = join(ibsdir, 'IBEIS_DUMP_names_table.csv')
+    rtbl_name = join(ibsdir, 'IBEIS_DUMP_annotations_table.csv')
     with open(gtbl_name, 'w') as file_:
         gtbl_str = ibs.db.get_table_csv('images', exclude_columns=[])
         file_.write(gtbl_str)
@@ -244,14 +244,14 @@ def get_hots_flat_table(ibs):
 
 
 def dump_hots_flat_table(ibs):
-    flat_table_fpath = join(ibs.dbdir, 'flat_table.csv')
+    flat_table_fpath = join(ibs.dbdir, 'IBEIS_DUMP_flat_table.csv')
     flat_table_str = ibs.get_flat_table()
     print('[ibs] dumping flat table to: %r' % flat_table_fpath)
     with open(flat_table_fpath, 'w') as file_:
         file_.write(flat_table_str)
 
 
-SUCCESS_FLAG_FNAME = '_hsdb_to_wbia_convert_success'
+SUCCESS_FLAG_FNAME = '_hsdb_to_ibeis_convert_success'
 
 
 if __name__ == '__main__':

--- a/wbia/dbio/ingest_hsdb.py
+++ b/wbia/dbio/ingest_hsdb.py
@@ -16,7 +16,7 @@ import csv
 print, rrr, profile = ut.inject2(__name__)
 
 
-SUCCESS_FLAG_FNAME = '_hsdb_to_wbia_convert_success'
+SUCCESS_FLAG_FNAME = '_hsdb_to_ibeis_convert_success'
 
 
 def is_hsdb(dbdir):


### PR DESCRIPTION
When running `python _dev/reset_dbs.py`:

```
Traceback (most recent call last):
  File "../_dev/reset_dbs.py", line 14, in <module>
    reset_testdbs.reset_testdbs()
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/wbia/tests/reset_testdbs.py", line 181, in reset_testdbs
    wbia.ensure_pz_mtest()
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/wbia/init/sysres.py", line 425, in ensure_pz_mtest
    ibs = wbia.opendb('PZ_MTEST')
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/wbia/main_module.py", line 600, in opendb
    ibs = _init_wbia(dbdir, verbose=verbose, use_cache=use_cache, web=web, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/wbia/main_module.py", line 113, in _init_wbia
    force_serial=force_serial,
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/wbia/control/IBEISControl.py", line 254, in request_IBEISController
    dbdir, ensure=ensure, wbaddr=wbaddr, verbose=verbose
  File "/opt/hostedtoolcache/Python/3.7.8/x64/lib/python3.7/site-packages/wbia/dbio/ingest_hsdb.py", line 335, in convert_hsdb_to_wbia
    assert len(ibs.get_valid_gids()) == 0, 'target database is not empty'
AssertionError: target database is not empty
```

This is because the hsdb has already been converted in the files downloaded
during `reset_dbs.py`.  But because we changed the `SUCCESS_FLAG_FNAME` in
`wbia/dbio/ingest_hsdb.py`, this couldn't be detected and the code tries to
convert the database again.

We need to have some kind of backwards compatibility code and possibly
migrations for all existing databases before attempting this again.

Partial revert of commit 42321675d0 "Small fixes for migrations":

```
git show 42321675d0 wbia/dbio/export_hsdb.py wbia/dbio/ingest_hsdb.py >a.diff
patch -p1 --reverse <a.diff
```

---

Towards #51