### PR TITLE
Skip doctest if gui flag is not supplied

### DIFF
--- a/wbia/guitool/api_item_model.py
+++ b/wbia/guitool/api_item_model.py
@@ -1082,6 +1082,7 @@ def simple_thumbnail_widget():
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> import wbia.guitool as guitool
         >>> from wbia.guitool.api_item_model import *  # NOQA
         >>> guitool.ensure_qapp()  # must be ensured before any embeding

--- a/wbia/guitool/api_item_view.py
+++ b/wbia/guitool/api_item_view.py
@@ -75,6 +75,7 @@ def _init_itemview_behavior(view):
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> # TODO figure out how to test these
         >>> from wbia.guitool.api_item_view import *  # NOQA
         >>> from wbia.guitool import api_table_view
@@ -326,6 +327,7 @@ def keyPressEvent(view, event):
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.api_item_view import *  # NOQA
         >>> import wbia.guitool as gt
         >>> app = gt.ensure_qapp()[0]

--- a/wbia/guitool/api_item_widget.py
+++ b/wbia/guitool/api_item_widget.py
@@ -36,6 +36,7 @@ def simple_api_item_widget():
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.api_item_widget import *  # NOQA
         >>> import wbia.guitool as gt
         >>> gt.ensure_qapp()  # must be ensured before any embeding
@@ -96,6 +97,7 @@ def simple_api_tree_widget():
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.api_item_widget import *  # NOQA
         >>> import wbia.guitool
         >>> guitool.ensure_qapp()  # must be ensured before any embeding

--- a/wbia/guitool/api_table_view.py
+++ b/wbia/guitool/api_table_view.py
@@ -67,8 +67,10 @@ class APITableView(API_VIEW_BASE):
 
         Example:
             >>> # ENABLE_DOCTEST
+            >>> # GUI_DOCTEST
+            >>> # xdoctest: +REQUIRES(--gui)
             >>> from wbia.guitool.api_table_view import *  # NOQA
-            >>> import wbia.guitool
+            >>> from wbia import guitool
             >>> guitool.ensure_qapp()
             >>> view = APITableView()
             >>> view._init_header_behavior()
@@ -122,8 +124,10 @@ class APITableView(API_VIEW_BASE):
 
         Example:
             >>> # ENABLE_DOCTEST
+            >>> # GUI_DOCTEST
+            >>> # xdoctest: +REQUIRES(--gui)
             >>> from wbia.guitool.api_table_view import *  # NOQA
-            >>> import wbia.guitool
+            >>> from wbia import guitool
             >>> guitool.ensure_qapp()
             >>> view = APITableView()
             >>> view._init_header_behavior()

--- a/wbia/guitool/api_thumb_delegate.py
+++ b/wbia/guitool/api_thumb_delegate.py
@@ -69,8 +69,10 @@ def read_thumb_as_qimg(thumb_path):
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.api_thumb_delegate import *  # NOQA
-        >>> import wbia.guitool
+        >>> from wbia import guitool
         >>> # build test data
         >>> thumb_path = ut.grab_test_imgpath('carl.jpg')
         >>> # execute function
@@ -469,6 +471,8 @@ def get_thread_thumb_info(bbox_list, theta_list, thumbsize, img_size):
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.api_thumb_delegate import *  # NOQA
         >>> # build test data
         >>> bbox_list = [(100, 50, 400, 200)]
@@ -501,6 +505,8 @@ def make_thread_thumb(img_path, dsize, new_verts_list, interest_list):
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.api_thumb_delegate import *  # NOQA
         >>> import wbia.plottool as pt
         >>> # build test data

--- a/wbia/guitool/api_tree_view.py
+++ b/wbia/guitool/api_tree_view.py
@@ -67,6 +67,7 @@ class APITreeView(API_VIEW_BASE):
 
         Example:
             >>> # ENABLE_DOCTEST
+            >>> # xdoctest: +REQUIRES(--gui)
             >>> # TODO figure out how to test these
             >>> from wbia.guitool.api_tree_view import *  # NOQA
             >>> import wbia.guitool as gt
@@ -128,6 +129,7 @@ def testdata_tree_view():
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> import wbia.guitool as gt
         >>> from wbia.guitool.api_tree_view import *  # NOQA
         >>> wgt = testdata_tree_view()

--- a/wbia/guitool/guitool_components.py
+++ b/wbia/guitool/guitool_components.py
@@ -44,6 +44,8 @@ def rectifyQtEnum(type_, value, default=ut.NoParam):
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> newvals = []
         >>> newvals.append(rectifyQtEnum('Orientation', 'vert'))
@@ -574,6 +576,8 @@ class ProgHook(QtCore.QObject, ut.NiceRepr):
 
         Example:
             >>> # ENABLE_DOCTEST
+            >>> # GUI_DOCTEST
+            >>> # xdoctest: +REQUIRES(--gui)
             >>> from wbia.guitool.guitool_components import *  # NOQA
             >>> import wbia.guitool as gt
             >>> app = gt.ensure_qtapp()[0]
@@ -924,6 +928,8 @@ def newLabel(parent=None, text='', align='center', gpath=None, fontkw={}, min_wi
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool
         >>> guitool.ensure_qtapp()
@@ -1077,6 +1083,8 @@ def newLineEdit(
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> parent = None
         >>> text = None
@@ -1129,6 +1137,8 @@ class TagEdit(QtWidgets.QLineEdit):
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool as gt
         >>> gt.ensure_qtapp()
@@ -1405,6 +1415,8 @@ class GuitoolWidget(WIDGET_BASE):
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool as gt
         >>> gt.ensure_qtapp()
@@ -1644,6 +1656,8 @@ class ConfigConfirmWidget(GuitoolWidget):
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool
         >>> import dtool
@@ -1959,6 +1973,8 @@ def newButton(
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool as gt
         >>> gt.ensure_qtapp()
@@ -2064,6 +2080,8 @@ def newComboBox(
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool as gt
         >>> gt.ensure_qtapp()
@@ -2226,6 +2244,8 @@ def newCheckBox(
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool as gt
         >>> app = gt.ensure_qtapp()[0]
@@ -2365,6 +2385,8 @@ class Spoiler(WIDGET_BASE):
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> # build test data
         >>> import wbia.guitool
@@ -2732,6 +2754,8 @@ class FlowLayout(QtWidgets.QLayout):
         python -m wbia.guitool.guitool_components FlowLayout
 
     Ignore:
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> import sys
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool as gt
@@ -2866,6 +2890,8 @@ class ComboRadioHybrid(GuitoolWidget):
 
     Example:
         >>> # ENABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_components import *  # NOQA
         >>> import wbia.guitool as gt
         >>> gt.ensure_qtapp()

--- a/wbia/guitool/guitool_dialogs.py
+++ b/wbia/guitool/guitool_dialogs.py
@@ -216,6 +216,8 @@ def newFileDialog(
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_dialogs import *  # NOQA
         >>> import wbia.guitool
         >>> guitool.ensure_qtapp()
@@ -573,7 +575,9 @@ def msgbox(msg='', title='msgbox', detailed_msg=None):
 
     Example:
         >>> # ENABLE_DOCTEST
-        >>> import wbia.guitool
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
+        >>> from wbia import guitool
         >>> guitool.ensure_qtapp()
         >>> from wbia.guitool.guitool_dialogs import *  # NOQA
         >>> from wbia.guitool.guitool_dialogs import _register_msgbox  # NOQA
@@ -661,6 +665,8 @@ def popup_menu(widget, pos, context_options):
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # GUI_DOCTEST
+        >>> # xdoctest: +REQUIRES(--gui)
         >>> from wbia.guitool.guitool_dialogs import *  # NOQA
         >>> import wbia.guitool
         >>> import wbia.plottool as pt


### PR DESCRIPTION
As suggested, I used `# xdoctest: +REQUIRES(--gui)` to disable these tests.

I did correct the guitool import in a few places, because it was difficult to see where the next error was actually occurring. I can remove that if you'd like, but it likely doesn't hurt anything either.