### PR TITLE
Automatically reset database on test run

### DIFF
--- a/wbia/tests/conftest.py
+++ b/wbia/tests/conftest.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# See also conftest.py documentation at https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions
+"""This module is implicitly used by ``pytest`` to load testing configuration and fixtures."""
+from pathlib import Path
+
+import pytest
+
+from wbia.init.sysres import (
+    ensure_nauts,
+    ensure_pz_mtest,
+    ensure_testdb2,
+    ensure_wilddogs,
+    get_workdir,
+    set_default_dbdir,
+)
+from .reset_testdbs import (
+    TEST_DBNAMES_MAP,
+    delete_dbdir,
+    ensure_smaller_testingdbs,
+)
+
+
+@pytest.fixture
+def enable_wildbook_signal():
+    """This sets the ``ENABLE_WILDBOOK_SIGNAL`` to False"""
+    # TODO (16-Jul-12020) Document ENABLE_WILDBOOK_SIGNAL
+    # ??? what is ENABLE_WILDBOOK_SIGNAL used for?
+    import wbia
+
+    setattr(wbia, 'ENABLE_WILDBOOK_SIGNAL', False)
+
+
+@pytest.fixture(scope='session', autouse=True)
+@pytest.mark.usefixtures('enable_wildbook_signal')
+def set_up_db():
+    """
+    Sets up the testing databases.
+    This fixture is set to run automatically any any test run of wbia.
+
+    """
+    # Delete DBs, if they exist
+    # FIXME (16-Jul-12020) this fixture does not cleanup after itself to preserve exiting usage behavior
+    for dbname in TEST_DBNAMES_MAP.values():
+        delete_dbdir(dbname)
+
+    # Set up DBs
+    ensure_smaller_testingdbs()
+    ensure_pz_mtest()
+    ensure_nauts()
+    ensure_wilddogs()
+    ensure_testdb2()
+
+    # Set testdb1 as the main database
+    workdir = Path(get_workdir())
+    default_db_dir = workdir / 'testdb1'
+    # FIXME (16-Jul-12020) Set this only for the test session
+    set_default_dbdir(default_db_dir.resolve())

--- a/wbia/tests/reset_testdbs.py
+++ b/wbia/tests/reset_testdbs.py
@@ -156,8 +156,6 @@ def ensure_smaller_testingdbs():
 
 def reset_testdbs(**kwargs):
     # Step 0) Parse Args
-    import wbia
-
     wbia.ENABLE_WILDBOOK_SIGNAL = False
     default_args = {'reset_' + key: False for key in six.iterkeys(TEST_DBNAMES_MAP)}
     default_args['reset_all'] = False
@@ -176,7 +174,7 @@ def reset_testdbs(**kwargs):
 
     # Step 3) Ensure DBs that dont exist
     ensure_smaller_testingdbs()
-    workdir = wbia.sysres.get_workdir()
+    workdir = sysres.get_workdir()
     if not ut.checkpath(join(workdir, 'PZ_MTEST'), verbose=True):
         wbia.ensure_pz_mtest()
     if not ut.checkpath(join(workdir, 'NAUT_test'), verbose=True):
@@ -187,7 +185,7 @@ def reset_testdbs(**kwargs):
         wbia.init.sysres.ensure_testdb2()
 
     # Step 4) testdb1 becomes the main database
-    workdir = wbia.sysres.get_workdir()
+    workdir = sysres.get_workdir()
     TESTDB1 = join(workdir, 'testdb1')
     sysres.set_default_dbdir(TESTDB1)
 


### PR DESCRIPTION
Adds a pytest fixture to automatically reset the databases at the beginning of every test run. This removes the need to run the `_dev/reset_db.py` script before running the tests. Thus it removes a user error prone step in the process and brings the process to a one step usage: `pytest`

Addresses #51 