### PR TITLE
Remove default_decorator

### DIFF
--- a/wbia/control/accessor_decors.py
+++ b/wbia/control/accessor_decors.py
@@ -48,20 +48,6 @@ if ut.VERBOSE:
 # -----------------
 
 
-# DECORATORS::OTHERS
-
-
-def default_decorator(input_):
-    """
-    DEPRICATE
-    This should be the first decorator applied to all Controller functions
-    """
-    func_ = input_
-    # return profile(func_)
-    # return ut.indent_func(profile(func_))
-    return func_
-
-
 # DECORATORS::ADDER
 
 
@@ -401,8 +387,6 @@ def dev_cache_getter(tblname, colname, *args, **kwargs):
 
 # @decorator.decorator
 def adder(func):
-    func_ = default_decorator(func)
-
     @ut.accepts_scalar_input
     @ut.ignores_exc_tb
     def wrp_adder(*args, **kwargs):
@@ -415,7 +399,7 @@ def adder(func):
         if VERB_CONTROL:
             print('[ADD]: ' + get_funcname(func))
             builtins.print('\n' + ut.func_str(func, args, kwargs) + '\n')
-        return func_(*args, **kwargs)
+        return func(*args, **kwargs)
 
     wrp_adder = ut.preserve_sig(wrp_adder, func)
     # wrp_adder = ut.on_exception_report_input(wrp_adder)
@@ -426,15 +410,13 @@ def adder(func):
 
 # @decorator.decorator
 def deleter(func):
-    func_ = default_decorator(func)
-
     @ut.accepts_scalar_input
     @ut.ignores_exc_tb
     def wrp_deleter(*args, **kwargs):
         if VERB_CONTROL:
             print('[DELETE]: ' + get_funcname(func))
             builtins.print('\n' + ut.func_str(func, args, kwargs) + '\n')
-        return func_(*args, **kwargs)
+        return func(*args, **kwargs)
 
     wrp_deleter = ut.preserve_sig(wrp_deleter, func)
     return wrp_deleter
@@ -443,15 +425,7 @@ def deleter(func):
 # DECORATORS::SETTER
 
 # @decorator.decorator
-# def setter_general(func):
-#    func = default_decorator(func)
-#    return func
-
-
-# @decorator.decorator
 def setter(func):
-    func_ = default_decorator(func)
-
     @ut.accepts_scalar_input2(argx_list=[0, 1], outer_wrapper=False)
     @ut.ignores_exc_tb
     def wrp_setter(*args, **kwargs):
@@ -464,7 +438,7 @@ def setter(func):
             print('L------')
             # builtins.print('\n' + funccall_str + '\n')
         # print('set: funcname=%r, args=%r, kwargs=%r' % (get_funcname(func), args, kwargs))
-        return func_(*args, **kwargs)
+        return func(*args, **kwargs)
 
     wrp_setter = ut.preserve_sig(wrp_setter, func)
     # wrp_setter = ut.on_exception_report_input(wrp_setter)
@@ -479,8 +453,6 @@ def getter(func):
     Getter decorator for functions which takes as the first input a unique id
     list and returns a heterogeous list of values
     """
-    # func_ = func
-    func_ = default_decorator(func)
 
     @ut.accepts_scalar_input
     @ut.ignores_exc_tb
@@ -494,7 +466,7 @@ def getter(func):
             funccall_str = ut.func_str(func, args, kwargs, packed=True)
             print('\n' + funccall_str + '\n')
             print('L------')
-        return func_(*args, **kwargs)
+        return func(*args, **kwargs)
 
     wrp_getter = ut.preserve_sig(wrp_getter, func)
     # wrp_getter = ut.on_exception_report_input(wrp_getter)
@@ -507,12 +479,11 @@ def getter_vector_output(func):
     Getter decorator for functions which takes as the first input a unique id
     list and returns a homogenous list of values
     """
-    func_ = default_decorator(func)
 
     @ut.accepts_scalar_input_vector_output
     @ut.ignores_exc_tb
     def getter_vector_wrp(*args, **kwargs):
-        return func_(*args, **kwargs)
+        return func(*args, **kwargs)
 
     getter_vector_wrp = ut.preserve_sig(getter_vector_wrp, func)
     return getter_vector_wrp
@@ -530,13 +501,12 @@ def getter_numpy(func):
     list and returns a heterogeous list of values
     """
     # getter_func = getter(func)
-    func_ = default_decorator(func)
 
     @ut.accepts_numpy
     @ut.accepts_scalar_input
     @ut.ignores_exc_tb
     def getter_numpy_wrp(*args, **kwargs):
-        return func_(*args, **kwargs)
+        return func(*args, **kwargs)
 
     getter_numpy_wrp = ut.preserve_sig(getter_numpy_wrp, func)
     # getter_numpy_wrp = ut.on_exception_report_input(getter_numpy_wrp)
@@ -550,13 +520,12 @@ def getter_numpy_vector_output(func):
     id list and returns a heterogeous list of values
     """
     # getter_func = getter_vector_output(func)
-    func_ = default_decorator(func)
 
     @ut.accepts_numpy
     @ut.accepts_scalar_input_vector_output
     @ut.ignores_exc_tb
     def getter_numpy_vector_wrp(*args, **kwargs):
-        return func_(*args, **kwargs)
+        return func(*args, **kwargs)
 
     getter_numpy_vector_wrp = ut.preserve_sig(getter_numpy_vector_wrp, func)
     return getter_numpy_vector_wrp
@@ -564,8 +533,7 @@ def getter_numpy_vector_output(func):
 
 def ider(func):
     """ This function takes returns ids subject to conditions """
-    ider_func = default_decorator(func)
-    ider_func = ut.preserve_sig(ider_func, func)
+    ider_func = ut.preserve_sig(func, func)
     return ider_func
 
 

--- a/wbia/control/manual_imageset_funcs.py
+++ b/wbia/control/manual_imageset_funcs.py
@@ -343,7 +343,6 @@ def get_imageset_fraction_annotmatch_reviewed(ibs, imgsetid_list):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 # @register_api('/api/imageset/aids/filtered/custom/', methods=['GET'])
 def get_imageset_custom_filtered_aids(ibs, imgsetid_list):
     r"""
@@ -581,7 +580,6 @@ def get_imageset_image_uuids(ibs, imgsetid_list):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 # @register_api('/api/imageset/gsgrids/', methods=['GET'])
 def get_imageset_gsgrids(ibs, imgsetid_list=None, gid_list=None):
     r"""
@@ -923,7 +921,6 @@ def get_imageset_gps_lats(ibs, imageset_rowid_list):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/imageset/info/', methods=['PUT'])
 def update_imageset_info(ibs, imageset_rowid_list, **kwargs):
     r"""

--- a/wbia/control/manual_lblannot_funcs.py
+++ b/wbia/control/manual_lblannot_funcs.py
@@ -10,7 +10,6 @@ from wbia.control.accessor_decors import (
     setter,
     getter_1to1,
     getter_1toM,
-    default_decorator,
     ider,
 )
 import utool as ut
@@ -151,7 +150,6 @@ def get_alr_annot_rowids(ibs, alrid_list):
 
 
 @register_ibs_method
-@default_decorator
 def get_alr_annot_rowids_from_lblannot_rowid(ibs, lblannot_rowid_list):
     """
     This is a 1toM getter

--- a/wbia/control/manual_lblimage_funcs.py
+++ b/wbia/control/manual_lblimage_funcs.py
@@ -7,7 +7,6 @@ from wbia import constants as const
 from wbia.control.accessor_decors import (
     adder,
     getter_1to1,
-    default_decorator,
     getter_1toM,
 )
 import utool as ut
@@ -166,7 +165,6 @@ def get_lblimage_values(ibs, lblimage_rowid_list, _lbltype=None):
 
 
 @register_ibs_method
-@default_decorator
 def get_lblimage_gids(ibs, lblimage_rowid_list):
     # verbose = len(lblimage_rowid_list) > 20
     # TODO: Optimize IF POSSIBLE

--- a/wbia/control/manual_meta_funcs.py
+++ b/wbia/control/manual_meta_funcs.py
@@ -1107,7 +1107,6 @@ def _default_config(ibs, cfgname=None, new=True):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/query/cfg/', methods=['PUT'])
 def update_query_cfg(ibs, **kwargs):
     r"""

--- a/wbia/web/apis_detect.py
+++ b/wbia/web/apis_detect.py
@@ -21,7 +21,6 @@ register_route = controller_inject.get_wbia_flask_route(__name__)
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1toM
 @register_api('/api/wic/cnn/', methods=['PUT', 'GET', 'POST'])
 def wic_cnn(ibs, gid_list, testing=False, algo='cnn', model_tag='candidacy', **kwargs):
@@ -46,14 +45,12 @@ def wic_cnn(ibs, gid_list, testing=False, algo='cnn', model_tag='candidacy', **k
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1to1
 def wic_cnn_json(ibs, gid_list, config={}, **kwargs):
     return wic_cnn(ibs, gid_list, **config)
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1to1
 @register_api('/api/detect/randomforest/', methods=['PUT', 'GET'])
 def detect_random_forest(ibs, gid_list, species, commit=True, **kwargs):
@@ -443,7 +440,6 @@ def process_detection_html(ibs, **kwargs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1to1
 def detect_cnn_json(ibs, gid_list, detect_func, config={}, **kwargs):
     """
@@ -507,7 +503,6 @@ def detect_cnn_json(ibs, gid_list, detect_func, config={}, **kwargs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 def detect_cnn_json_wrapper(ibs, image_uuid_list, detect_func, **kwargs):
     """
     Detect with CNN (general).
@@ -529,7 +524,6 @@ def detect_cnn_json_wrapper(ibs, image_uuid_list, detect_func, **kwargs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/detect/cnn/yolo/json/', methods=['POST'])
 def detect_cnn_yolo_json_wrapper(ibs, image_uuid_list, **kwargs):
     return detect_cnn_json_wrapper(
@@ -538,14 +532,12 @@ def detect_cnn_yolo_json_wrapper(ibs, image_uuid_list, **kwargs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1to1
 def detect_cnn_yolo_json(ibs, gid_list, config={}, **kwargs):
     return detect_cnn_json(ibs, gid_list, ibs.detect_cnn_yolo, config=config, **kwargs)
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1toM
 @register_api('/api/detect/cnn/yolo/', methods=['PUT', 'GET', 'POST'])
 def detect_cnn_yolo(ibs, gid_list, model_tag=None, commit=True, testing=False, **kwargs):
@@ -705,7 +697,6 @@ def models_cnn(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1toM
 @register_api('/api/labeler/cnn/', methods=['PUT', 'GET', 'POST'])
 def labeler_cnn(
@@ -733,7 +724,6 @@ def labeler_cnn(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1toM
 @register_api('/api/aoi/cnn/', methods=['PUT', 'GET', 'POST'])
 def aoi_cnn(ibs, aid_list, testing=False, model_tag='candidacy', **kwargs):
@@ -757,7 +747,6 @@ def aoi_cnn(ibs, aid_list, testing=False, model_tag='candidacy', **kwargs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1to1
 @register_api('/api/detect/cnn/yolo/exists/', methods=['GET'], __api_plural_check__=False)
 def detect_cnn_yolo_exists(ibs, gid_list, testing=False):
@@ -807,7 +796,6 @@ def detect_cnn_yolo_exists(ibs, gid_list, testing=False):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/detect/cnn/lightnet/json/', methods=['POST'])
 def detect_cnn_lightnet_json_wrapper(ibs, image_uuid_list, **kwargs):
     return detect_cnn_json_wrapper(
@@ -816,7 +804,6 @@ def detect_cnn_lightnet_json_wrapper(ibs, image_uuid_list, **kwargs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1to1
 def detect_cnn_lightnet_json(ibs, gid_list, config={}, **kwargs):
     return detect_cnn_json(
@@ -825,7 +812,6 @@ def detect_cnn_lightnet_json(ibs, gid_list, config={}, **kwargs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @accessor_decors.getter_1toM
 @register_api('/api/detect/cnn/lightnet/', methods=['PUT', 'GET', 'POST'])
 def detect_cnn_lightnet(
@@ -1134,7 +1120,6 @@ def log_detections(ibs, aid_list, fallback=True):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/detect/species/enabled/', methods=['GET'], __api_plural_check__=False)
 def has_species_detector(ibs, species_text):
     """
@@ -1149,7 +1134,6 @@ def has_species_detector(ibs, species_text):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/detect/species/', methods=['GET'], __api_plural_check__=False)
 def get_species_with_detectors(ibs):
     """
@@ -1164,7 +1148,6 @@ def get_species_with_detectors(ibs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/detect/species/working/', methods=['GET'], __api_plural_check__=False)
 def get_working_species(ibs):
     """
@@ -1191,7 +1174,6 @@ def get_working_species(ibs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/detect/whaleSharkInjury/', methods=['PUT', 'GET'])
 def detect_ws_injury(ibs, gid_list):
     """

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import six
 import utool as ut
 import uuid  # NOQA
-from wbia.control import accessor_decors, controller_inject
+from wbia.control import controller_inject
 import wbia.constants as const
 
 print, rrr, profile = ut.inject2(__name__)
@@ -93,7 +93,6 @@ def web_check_annot_uuids_with_names(annot_uuid_list, name_list):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/uuid/check/', methods=['GET', 'POST'])
 def web_check_uuids(ibs, image_uuid_list=[], qannot_uuid_list=[], dannot_uuid_list=[]):
     r"""
@@ -188,7 +187,6 @@ def web_check_uuids(ibs, image_uuid_list=[], qannot_uuid_list=[], dannot_uuid_li
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/query/annot/rowid/', methods=['GET', 'POST'])
 def start_identify_annots(
     ibs,
@@ -329,7 +327,6 @@ def start_identify_annots(
 
 
 @register_ibs_method
-# @accessor_decors.default_decorator
 @register_api('/api/engine/query/graph/complete/', methods=['GET', 'POST'])
 def start_identify_annots_query_complete(
     ibs,
@@ -401,7 +398,6 @@ def start_identify_annots_query_complete(
 
 
 @register_ibs_method
-# @accessor_decors.default_decorator
 @register_api('/api/engine/query/graph/', methods=['GET', 'POST'])
 def start_identify_annots_query(
     ibs,
@@ -624,7 +620,6 @@ def start_identify_annots_query(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/wic/cnn/', methods=['POST'])
 def start_wic_image(
     ibs, image_uuid_list, callback_url=None, callback_method=None, **kwargs
@@ -662,7 +657,6 @@ def start_wic_image(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/detect/cnn/yolo/', methods=['POST'])
 def start_detect_image_yolo(
     ibs, image_uuid_list, callback_url=None, callback_method=None, **kwargs
@@ -700,7 +694,6 @@ def start_detect_image_yolo(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/labeler/cnn/', methods=['POST'])
 def start_labeler_cnn(
     ibs, annot_uuid_list, callback_url=None, callback_method=None, **kwargs
@@ -729,7 +722,6 @@ def start_labeler_cnn(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/review/query/chip/best/', methods=['POST'])
 def start_review_query_chips_best(
     ibs, annot_uuid, callback_url=None, callback_method=None, **kwargs
@@ -758,7 +750,6 @@ def start_review_query_chips_best(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/test/engine/detect/cnn/yolo/', methods=['GET'])
 def start_detect_image_test_yolo(ibs):
     from random import shuffle  # NOQA
@@ -772,7 +763,6 @@ def start_detect_image_test_yolo(ibs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/detect/cnn/lightnet/', methods=['POST', 'GET'])
 def start_detect_image_lightnet(
     ibs, image_uuid_list, callback_url=None, callback_method=None, **kwargs
@@ -810,7 +800,6 @@ def start_detect_image_lightnet(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/test/engine/detect/cnn/lightnet/', methods=['GET'])
 def start_detect_image_test_lightnet(ibs):
     from random import shuffle  # NOQA
@@ -824,7 +813,6 @@ def start_detect_image_test_lightnet(ibs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/classify/whaleshark/injury/', methods=['POST'])
 def start_predict_ws_injury_interim_svm(
     ibs, annot_uuid_list, callback_url=None, callback_method=None, **kwargs
@@ -879,7 +867,6 @@ def start_predict_ws_injury_interim_svm(
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/query/web/', methods=['GET'])
 def start_web_query_all(ibs):
     """
@@ -892,7 +879,6 @@ def start_web_query_all(ibs):
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/engine/flukebook/sync/', methods=['GET'])
 def start_flukebook_sync(ibs, **kwargs):
     """

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -6,7 +6,7 @@ SeeAlso:
     routes.turk_identification
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
-from wbia.control import accessor_decors, controller_inject
+from wbia.control import controller_inject
 from wbia.algo.hots import pipeline
 from flask import url_for, request, current_app  # NOQA
 from os.path import join, dirname, abspath, exists
@@ -33,7 +33,6 @@ GRAPH_CLIENT_PEEK = 100
 
 
 @register_ibs_method
-@accessor_decors.default_decorator
 @register_api('/api/query/annot/rowid/', methods=['GET'])
 def get_recognition_query_aids(ibs, is_known, species=None):
     """


### PR DESCRIPTION
According to the docstring this is deprecated. According to the code's
logic it does nothing.

This was low hanging fruit, so I just picked it. It was accomplished with a simple sed command like: `sed '/@default_decorator/d' module.py`