### PR TITLE
Make sure opendb_bg_web servers are terminated in tests

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,8 @@ jobs:
 
       - name: Build wheel
         env:
-          CIBW_SKIP: cp27-* pp27-* pp36-*
+          CIBW_BUILD: cp3?-*
+          CIBW_SKIP: cp35-* *-win32 *-win_amd64 *-manylinux_i686 *-manylinux_aarch64 *-manylinux_ppc64le *-manylinux_s390x
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
           CIBW_TEST_COMMAND: python -c "import wbia; from wbia.__main__ import main; main()"
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Build wheel
         env:
           CIBW_SKIP: cp27-* pp27-* pp36-*
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
           CIBW_TEST_COMMAND: python -c "import wbia; from wbia.__main__ import main; main()"
         run: |
           python -m pip install cibuildwheel==1.4.2

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -1144,12 +1144,11 @@ class IBEISController(BASE_CLASS):
             >>> from wbia.control.IBEISControl import *  # NOQA
             >>> import wbia
             >>> import wbia.web
-            >>> web_ibs = wbia.opendb_bg_web('testdb1', wait=.5, start_job_queue=False)
-            >>> resp = web_ibs.send_wbia_request('/log/current/', 'get')
+            >>> with wbia.opendb_bg_web('testdb1', wait=.5, start_job_queue=False, managed=True) as web_ibs:
+            ...     resp = web_ibs.send_wbia_request('/log/current/', 'get')
             >>> print('\n-------Logs ----: \n' )
             >>> print(resp)
             >>> print('\nL____ END LOGS ___\n')
-            >>> web_ibs.terminate2()
         """
         text = ut.get_current_log_text()
         return text

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -1144,7 +1144,7 @@ class IBEISController(BASE_CLASS):
             >>> from wbia.control.IBEISControl import *  # NOQA
             >>> import wbia
             >>> import wbia.web
-            >>> with wbia.opendb_bg_web('testdb1', wait=.5, start_job_queue=False, managed=True) as web_ibs:
+            >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
             ...     resp = web_ibs.send_wbia_request('/log/current/', 'get')
             >>> print('\n-------Logs ----: \n' )
             >>> print(resp)

--- a/wbia/control/manual_wildbook_funcs.py
+++ b/wbia/control/manual_wildbook_funcs.py
@@ -442,13 +442,13 @@ def wildbook_signal_imgsetid_list(
         >>> set_shipped_flag = True
         >>> open_url_on_complete = True
         >>> if ut.get_argflag('--bg'):
-        >>>     web_ibs = wbia.opendb_bg_web(defaultdb)
-        >>> result = ibs.wildbook_signal_imgsetid_list(imgsetid_list, set_shipped_flag, open_url_on_complete, wb_target, dryrun)
+        >>>     with wbia.opendb_bg_web(defaultdb, managed=True) as web_ibs:
+        ...         result = web_ibs.wildbook_signal_imgsetid_list(imgsetid_list, set_shipped_flag, open_url_on_complete, wb_target, dryrun)
+        >>> else:
+        ...     result = ibs.wildbook_signal_imgsetid_list(imgsetid_list, set_shipped_flag, open_url_on_complete, wb_target, dryrun)
         >>> # cleanup
         >>> #ibs.delete_imagesets(new_imgsetid)
         >>> print(result)
-        >>> if ut.get_argflag('--bg'):
-        >>>     web_ibs.terminate2()
 
     """
     try:

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -69,10 +69,9 @@ def image_src_api(rowid=None, thumbnail=False, fresh=False, **kwargs):
         >>> # xdoctest: +REQUIRES(--web)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1', start_job_queue=False)
-        >>> web_ibs.send_wbia_request('/api/image/src/', type_='get', gid=1)
+        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
+        ...     web_ibs.send_wbia_request('/api/image/src/', type_='get', gid=1)
         >>> print(resp)
-        >>> web_ibs.terminate2()
 
     RESTful:
         Method: GET
@@ -127,10 +126,9 @@ def annot_src_api(rowid=None, fresh=False, **kwargs):
         >>> # WEB_DOCTEST
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1', start_job_queue=False)
-        >>> web_ibs.send_wbia_request('/api/annot/src/', type_='get', aid=1)
+        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
+        ...     web_ibs.send_wbia_request('/api/annot/src/', type_='get', aid=1)
         >>> print(resp)
-        >>> web_ibs.terminate2()
 
     RESTful:
         Method: GET
@@ -175,10 +173,9 @@ def background_src_api(rowid=None, fresh=False, **kwargs):
         >>> # WEB_DOCTEST
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1', start_job_queue=False)
-        >>> web_ibs.send_wbia_request('/api/annot/src/', type_='get', aid=1)
+        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
+        ...     web_ibs.send_wbia_request('/api/annot/src/', type_='get', aid=1)
         >>> print(resp)
-        >>> web_ibs.terminate2()
 
     RESTful:
         Method: GET
@@ -223,10 +220,9 @@ def image_src_api_json(uuid=None, **kwargs):
         >>> # xdoctest: +REQUIRES(--web)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1', start_job_queue=False)
-        >>> web_ibs.send_wbia_request('/api/image/src/', type_='get', gid=1)
+        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
+        ...     web_ibs.send_wbia_request('/api/image/src/', type_='get', gid=1)
         >>> print(resp)
-        >>> web_ibs.terminate2()
 
     RESTful:
         Method: GET
@@ -445,19 +441,18 @@ def hello_world(*args, **kwargs):
         >>> import wbia
         >>> import requests
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1', start_job_queue=False)
-        >>> web_port = ibs.get_web_port_via_scan()
-        >>> if web_port is None:
-        >>>     raise ValueError('IA web server is not running on any expected port')
-        >>> domain = 'http://127.0.0.1:%s' % (web_port, )
-        >>> url = domain + '/api/test/helloworld/?test0=0'
-        >>> payload = {
-        >>>     'test1' : 'test1',
-        >>>     'test2' : None,  # NOTICE test2 DOES NOT SHOW UP
-        >>> }
-        >>> resp = requests.post(url, data=payload)
-        >>> print(resp)
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
+        ...     web_port = ibs.get_web_port_via_scan()
+        ...     if web_port is None:
+        ...         raise ValueError('IA web server is not running on any expected port')
+        ...     domain = 'http://127.0.0.1:%s' % (web_port, )
+        ...     url = domain + '/api/test/helloworld/?test0=0'
+        ...     payload = {
+        ...         'test1' : 'test1',
+        ...         'test2' : None,  # NOTICE test2 DOES NOT SHOW UP
+        ...     }
+        ...     resp = requests.post(url, data=payload)
+        ...     print(resp)
     """
     print('+------------ HELLO WORLD ------------')
     print('Args: %r' % (args,))

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -70,7 +70,7 @@ def image_src_api(rowid=None, thumbnail=False, fresh=False, **kwargs):
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     web_ibs.send_wbia_request('/api/image/src/', type_='get', gid=1)
+        ...     web_ibs.send_wbia_request('/api/image/src/1/', type_='get')
         >>> print(resp)
 
     RESTful:
@@ -127,7 +127,7 @@ def annot_src_api(rowid=None, fresh=False, **kwargs):
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     web_ibs.send_wbia_request('/api/annot/src/', type_='get', aid=1)
+        ...     web_ibs.send_wbia_request('/api/annot/src/1/', type_='get')
         >>> print(resp)
 
     RESTful:
@@ -174,7 +174,7 @@ def background_src_api(rowid=None, fresh=False, **kwargs):
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     web_ibs.send_wbia_request('/api/annot/src/', type_='get', aid=1)
+        ...     web_ibs.send_wbia_request('/api/background/src/1/', type_='get')
         >>> print(resp)
 
     RESTful:
@@ -221,7 +221,7 @@ def image_src_api_json(uuid=None, **kwargs):
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     web_ibs.send_wbia_request('/api/image/src/', type_='get', gid=1)
+        ...     web_ibs.send_wbia_request('/api/image/src/json/1/', type_='get')
         >>> print(resp)
 
     RESTful:

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -437,7 +437,7 @@ def hello_world(*args, **kwargs):
         >>> web_ibs = wbia.opendb_bg_web(browser=True, start_job_queue=False, url_suffix='/api/test/helloworld/?test0=0')  # start_job_queue=False)
         >>> print('web_ibs = %r' % (web_ibs,))
         >>> print('Server will run until control c')
-        >>> #web_ibs.terminate2()
+        >>> web_ibs.terminate2()
 
     Example1:
         >>> # xdoctest: +REQUIRES(--web)

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -262,28 +262,27 @@ def start_identify_annots(
         >>> # xdoctest: +REQUIRES(--web)
         >>> from wbia.web.apis_engine import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1')  # , domain='http://52.33.105.88')
-        >>> aids = web_ibs.send_wbia_request('/api/annot/', 'get')[0:2]
-        >>> uuid_list = web_ibs.send_wbia_request('/api/annot/uuid/', type_='get', aid_list=aids)
-        >>> quuid_list = ut.get_argval('--quuids', type_=list, default=uuid_list)
-        >>> duuid_list = ut.get_argval('--duuids', type_=list, default=uuid_list)
-        >>> data = dict(
-        >>>     qannot_uuid_list=quuid_list, dannot_uuid_list=duuid_list,
-        >>>     pipecfg={},
-        >>>     callback_url='http://127.0.1.1:5832'
-        >>> )
-        >>> # Start callback server
-        >>> bgserver = ensure_simple_server()
-        >>> # --
-        >>> jobid = web_ibs.send_wbia_request('/api/engine/query/annot/rowid/', **data)
-        >>> status_response = web_ibs.wait_for_results(jobid, delays=[1, 5, 30])
-        >>> print('status_response = %s' % (status_response,))
-        >>> result_response = web_ibs.read_engine_results(jobid)
-        >>> print('result_response = %s' % (result_response,))
-        >>> cm_dict = result_response['json_result'][0]
-        >>> print('Finished test')
-        >>> web_ibs.terminate2()
-        >>> bgserver.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
+        ...     aids = web_ibs.send_wbia_request('/api/annot/', 'get')[0:2]
+        ...     uuid_list = web_ibs.send_wbia_request('/api/annot/uuid/', type_='get', aid_list=aids)
+        ...     quuid_list = ut.get_argval('--quuids', type_=list, default=uuid_list)
+        ...     duuid_list = ut.get_argval('--duuids', type_=list, default=uuid_list)
+        ...     data = dict(
+        ...         qannot_uuid_list=quuid_list, dannot_uuid_list=duuid_list,
+        ...         pipecfg={},
+        ...         callback_url='http://127.0.1.1:5832'
+        ...     )
+        ...     # Start callback server
+        ...     bgserver = ensure_simple_server()
+        ...     # --
+        ...     jobid = web_ibs.send_wbia_request('/api/engine/query/annot/rowid/', **data)
+        ...     status_response = web_ibs.wait_for_results(jobid, delays=[1, 5, 30])
+        ...     print('status_response = %s' % (status_response,))
+        ...     result_response = web_ibs.read_engine_results(jobid)
+        ...     print('result_response = %s' % (result_response,))
+        ...     cm_dict = result_response['json_result'][0]
+        ...     print('Finished test')
+        ...     bgserver.terminate2()
 
     Ignore:
         qaids = daids = ibs.get_valid_aids()
@@ -448,30 +447,29 @@ def start_identify_annots_query(
         >>> import wbia
         >>> #domain = 'localhost'
         >>> domain = None
-        >>> web_ibs = wbia.opendb_bg_web('testdb1', domain=domain)  # , domain='http://52.33.105.88')
-        >>> aids = web_ibs.send_wbia_request('/api/annot/', 'get')[0:3]
-        >>> uuid_list = web_ibs.send_wbia_request('/api/annot/uuid/', type_='get', aid_list=aids)
-        >>> quuid_list = ut.get_argval('--quuids', type_=list, default=uuid_list)[0:1]
-        >>> duuid_list = ut.get_argval('--duuids', type_=list, default=uuid_list)
-        >>> query_config_dict = {
-        >>>    #'pipeline_root' : 'BC_DTW'
-        >>> }
-        >>> data = dict(
-        >>>     query_annot_uuid_list=quuid_list, database_annot_uuid_list=duuid_list,
-        >>>     query_config_dict=query_config_dict,
-        >>> )
-        >>> jobid = web_ibs.send_wbia_request('/api/engine/query/graph/', **data)
-        >>> print('jobid = %r' % (jobid,))
-        >>> status_response = web_ibs.wait_for_results(jobid)
-        >>> result_response = web_ibs.read_engine_results(jobid)
-        >>> print('result_response = %s' % (ut.repr3(result_response),))
-        >>> inference_result = result_response['json_result']
-        >>> if isinstance(inference_result, six.string_types):
-        >>>    print(inference_result)
-        >>> cm_dict = inference_result['cm_dict']
-        >>> quuid = quuid_list[0]
-        >>> cm = cm_dict[str(quuid)]
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', domain=domain, managed=True) as web_ibs:  # , domain='http://52.33.105.88')
+        ...     aids = web_ibs.send_wbia_request('/api/annot/', 'get')[0:3]
+        ...     uuid_list = web_ibs.send_wbia_request('/api/annot/uuid/', type_='get', aid_list=aids)
+        ...     quuid_list = ut.get_argval('--quuids', type_=list, default=uuid_list)[0:1]
+        ...     duuid_list = ut.get_argval('--duuids', type_=list, default=uuid_list)
+        ...     query_config_dict = {
+        ...        #'pipeline_root' : 'BC_DTW'
+        ...     }
+        ...     data = dict(
+        ...         query_annot_uuid_list=quuid_list, database_annot_uuid_list=duuid_list,
+        ...         query_config_dict=query_config_dict,
+        ...     )
+        ...     jobid = web_ibs.send_wbia_request('/api/engine/query/graph/', **data)
+        ...     print('jobid = %r' % (jobid,))
+        ...     status_response = web_ibs.wait_for_results(jobid)
+        ...     result_response = web_ibs.read_engine_results(jobid)
+        ...     print('result_response = %s' % (ut.repr3(result_response),))
+        ...     inference_result = result_response['json_result']
+        ...     if isinstance(inference_result, six.string_types):
+        ...        print(inference_result)
+        ...     cm_dict = inference_result['cm_dict']
+        ...     quuid = quuid_list[0]
+        ...     cm = cm_dict[str(quuid)]
 
     """
     valid_states = {

--- a/wbia/web/job_engine.py
+++ b/wbia/web/job_engine.py
@@ -158,20 +158,19 @@ def initialize_job_manager(ibs):
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> import requests
-        >>> web_instance = wbia.opendb_bg_web(db='testdb1')
-        >>> web_port = ibs.get_web_port_via_scan()
-        >>> if web_port is None:
-        >>>     raise ValueError('IA web server is not running on any expected port')
-        >>> baseurl = 'http://127.0.1.1:%s' % (web_port, )
-        >>> _payload = {'image_attrs_list': [], 'annot_attrs_list': []}
-        >>> payload = ut.map_dict_vals(ut.to_json, _payload)
-        >>> resp1 = requests.post(baseurl + '/api/test/helloworld/?f=b', data=payload)
-        >>> #resp2 = requests.post(baseurl + '/api/image/json/', data=payload)
-        >>> #print(resp2)
-        >>> web_instance.terminate()
-        >>> #json_dict = resp2.json()
-        >>> #text = json_dict['response']
-        >>> #print(text)
+        >>> with wbia.opendb_bg_web(db='testdb1', managed=True) as web_instance:
+        ...     web_port = ibs.get_web_port_via_scan()
+        ...     if web_port is None:
+        ...         raise ValueError('IA web server is not running on any expected port')
+        ...     baseurl = 'http://127.0.1.1:%s' % (web_port, )
+        ...     _payload = {'image_attrs_list': [], 'annot_attrs_list': []}
+        ...     payload = ut.map_dict_vals(ut.to_json, _payload)
+        ...     resp1 = requests.post(baseurl + '/api/test/helloworld/?f=b', data=payload)
+        ...     #resp2 = requests.post(baseurl + '/api/image/json/', data=payload)
+        ...     #print(resp2)
+        ...     #json_dict = resp2.json()
+        ...     #text = json_dict['response']
+        ...     #print(text)
     """
     ibs.job_manager = ut.DynStruct()
 
@@ -247,10 +246,9 @@ def get_job_id_list(ibs):
         >>> # xdoctest: +REQUIRES(--web)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1')  # , domain='http://52.33.105.88')
-        >>> # Test get status of a job id that does not exist
-        >>> response = web_ibs.send_wbia_request('/api/engine/job/', jobid='badjob')
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
+        ...     # Test get status of a job id that does not exist
+        ...     response = web_ibs.send_wbia_request('/api/engine/job/', jobid='badjob')
 
     """
     status = ibs.job_manager.jobiface.get_job_id_list()
@@ -290,10 +288,9 @@ def get_job_status(ibs, jobid=None):
         >>> # xdoctest: +REQUIRES(--web)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1')  # , domain='http://52.33.105.88')
-        >>> # Test get status of a job id that does not exist
-        >>> response = web_ibs.send_wbia_request('/api/engine/job/status/', jobid='badjob')
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
+        ...     # Test get status of a job id that does not exist
+        ...     response = web_ibs.send_wbia_request('/api/engine/job/status/', jobid='badjob')
 
     """
     if jobid is None:
@@ -327,10 +324,9 @@ def get_job_metadata(ibs, jobid):
         >>> # WEB_DOCTEST
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1')  # , domain='http://52.33.105.88')
-        >>> # Test get metadata of a job id that does not exist
-        >>> response = web_ibs.send_wbia_request('/api/engine/job/metadata/', jobid='badjob')
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
+        ...     # Test get metadata of a job id that does not exist
+        ...     response = web_ibs.send_wbia_request('/api/engine/job/metadata/', jobid='badjob')
 
     """
     status = ibs.job_manager.jobiface.get_job_metadata(jobid)

--- a/wbia/web/routes.py
+++ b/wbia/web/routes.py
@@ -4003,9 +4003,8 @@ def turk_identification(
         >>> # SCRIPT
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1')
-        >>> resp = web_ibs.get('/turk/identification/lnbnn/')
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:
+        ...     resp = web_ibs.get('/turk/identification/lnbnn/')
         >>> ut.quit_if_noshow()
         >>> import wbia.plottool as pt
         >>> ut.render_html(resp.content)
@@ -4708,9 +4707,8 @@ def turk_identification_hardcase(*args, **kwargs):
         >>> # SCRIPT
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('PZ_Master1')
-        >>> resp = web_ibs.get('/turk/identification/hardcase/')
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('PZ_Master1', managed=True) as web_ibs:
+        ...     resp = web_ibs.get('/turk/identification/hardcase/')
 
     Ignore:
         import wbia
@@ -4769,9 +4767,8 @@ def turk_identification_graph(
         >>> # SCRIPT
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web('testdb1')
-        >>> resp = web_ibs.get('/turk/identification/graph/')
-        >>> web_ibs.terminate2()
+        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:
+        ...     resp = web_ibs.get('/turk/identification/graph/')
         >>> ut.quit_if_noshow()
         >>> import wbia.plottool as pt
         >>> ut.render_html(resp.content)


### PR DESCRIPTION
(**Note:** The first 2 commits are from #66)

- Terminate server in web api hello_world test

  The doc test intentionally leave the server running with
  `web_ibs.terminate2()` commented out.  This is not ideal as pytest /
  xdoctest hangs after all the tests are finished.

- Add optional context manager for opendb_bg_web

  We use `opendb_bg_web` in tests a lot.  We start the server then do
  stuff and terminate the server at the end.  If anything fails in the
  middle, the server isn't terminated.  It's better to clean that up so
  the servers aren't running in the background even if the tests fail.
  
  Add `managed=True` when calling `opendb_bg_web` to terminate the server
  when the block is completed.
  
  ```
  with opendb_bg_web(managed=True) as web_ibs:
      web_ibs.send_wbia_request(...)
  ```

- Change opendb_bg_web in tests to use managed=True

  pytest / xdoctest hangs when all the tests finish running.  Some of the
  web tests start a server and doesn't terminate it because the test fails
  in the middle.
  
  This should ensure that servers are terminated even if the tests fail.

- Update paths to match functions in web/apis.py doctests

  The tests weren't actually hitting the functions that they were testing.
  For example, the test for `image_src_api:0`:
  
  ```
  web_ibs.send_wbia_request('/api/image/src/', type_='get', gid=1)
  ```
  
  is actually hitting `image_base64_api` in
  `control/manual_image_funcs.py` which has path `/api/image/<rowid>/`.
  
  Updating the path to `/api/image/src/1/` fixes it.

- Remove wait from IBEISControl.get_current_log test

  ```
  DOCTEST TRACEBACK
   Traceback (most recent call last):
     File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 556, in run
       exec(code, test_globals)
     File "<doctest:wbia/control/IBEISControl.py::IBEISController.get_current_log_text:0>", line rel: 5, abs: 1147, in <module>
       >>> with wbia.opendb_bg_web('testdb1', wait=.5, start_job_queue=False, managed=True) as web_ibs:
     File "/wbia/wildbook-ia/wbia/main_module.py", line 415, in opendb_bg_web
       web_ibs = opendb_in_background(*args, **_kw)
     File "/wbia/wildbook-ia/wbia/main_module.py", line 358, in opendb_in_background
       raise AssertionError('wait is depricated')
   AssertionError: wait is depricated
  ```

(**Note:** The first 2 commits are from #66)