### PR TITLE
Lift dumping procedure and simplify

### DIFF
--- a/wbia/control/DB_SCHEMA.py
+++ b/wbia/control/DB_SCHEMA.py
@@ -17,6 +17,7 @@ CommandLine:
 from __future__ import absolute_import, division, print_function
 from wbia import constants as const
 from wbia.control import _sql_helpers
+from wbia.dtool.dump import dumps
 import utool as ut
 
 (print, rrr, profile) = ut.inject2(__name__)
@@ -2167,7 +2168,7 @@ def dump_schema_sql():
 
     db = dt.SQLDatabaseController(fpath=':memory:')
     DB_SCHEMA_CURRENT.update_current(db)
-    dump_str = db.dump_to_string()
+    dump_str = dumps(db.connection)
     print(dump_str)
 
     for tablename in db.get_table_names():

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -46,6 +46,8 @@ from wbia.init import sysres
 from wbia.dbio import ingest_hsdb
 from wbia import constants as const
 from wbia.control import accessor_decors, controller_inject
+from wbia.dtool.dump import dump
+
 
 # Inject utool functions
 (print, rrr, profile) = ut.inject2(__name__)
@@ -591,7 +593,6 @@ class IBEISController(BASE_CLASS):
         ibs._init_sqldbcore(request_dbversion=request_dbversion)
         ibs._init_sqldbstaging(request_stagingversion=request_stagingversion)
         # ibs.db.dump_schema()
-        # ibs.db.dump()
         ibs._init_rowid_constants()
 
     def _needs_backup(ibs):
@@ -1177,7 +1178,8 @@ class IBEISController(BASE_CLASS):
     def dump_database_csv(ibs):
         dump_dir = join(ibs.get_dbdir(), 'CSV_DUMP')
         ibs.db.dump_tables_to_csv(dump_dir=dump_dir)
-        ibs.db.dump_to_fpath(dump_fpath=join(dump_dir, '_ibsdb.dump'))
+        with open(join(dump_dir, '_ibsdb.dump'), 'w') as fp:
+            dump(ibs.db.connection, fp)
 
     def get_database_icon(ibs, max_dsize=(None, 192), aid=None):
         r"""

--- a/wbia/dtool/dump.py
+++ b/wbia/dtool/dump.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""Operations for dumping a database to file"""
+__all__ = (
+    'dump',
+    'dumps',
+)
+
+
+def _iter_dump(db_connection, schema_only=False):
+    """\
+    Generator function that serializes the database associated with
+    ``db_connection`` as formatted ``str``.
+
+    Args:
+        db_connection (sqlite3.Connection): database instance to dump
+        schema_only (bool): flag to only dump the schema
+
+    Returns:
+        str: serialized string of database
+
+    """
+    for line in db_connection.iterdump():
+        # ??? (23-Jul-12020) This seems a bit dicey, good idea?
+        #     This may only work in sqlite environment.
+        if schema_only and line.startswith('INSERT'):
+            # FIXME (23-Jul-12020) hardcoded table name, use METADATA_TABLE
+            #       when circular import is resolved.
+            # if metadata is requested then allow those inserts
+            if 'INSERT INTO "metadata' not in line:
+                continue
+        yield f'{line}\n'
+
+
+def dumps(*args, **kwargs):
+    """\
+    Serialize the database associated with ``db_connection`` as formatted ``str``.
+
+    Args:
+        db_connection (sqlite3.Connection): database instance to dump
+        schema_only (bool): flag to only dump the schema
+
+    Returns:
+        str: serialized string of database
+
+    """
+
+    return ''.join([s for s in _iter_dump(*args, **kwargs)])
+
+
+def dump(db_connection, fp, **kwargs):
+    """\
+    Serialize the database associated with ``db_connection`` as a formatted
+    stream to ``fp`` (a ``.write()``-supporting file-like object).
+
+    This is a side-effect only function that writes to ``fp``.
+
+    Args:
+        db_connection (sqlite3.Connection): database instance to dump
+        fp (file-like object): output stream
+        schema_only (bool): flag to only dump the schema
+
+    Returns:
+        None
+
+    """
+    for line in _iter_dump(db_connection, **kwargs):
+        fp.write(line)

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -241,10 +241,6 @@ class SQLExecutionContext(object):
             # An SQLError is a serious offence.
             print('[sql] FATAL ERROR IN QUERY CONTEXT')
             print('[sql] operation=\n' + context.operation)
-            DUMP_ON_EXCEPTION = False
-            if DUMP_ON_EXCEPTION:
-                # Dump on error
-                context.db.dump()
             print('[sql] Error in context manager!: ' + str(value))
             # return a falsey value on error
             return False

--- a/wbia/tests/dtool/test_dump.py
+++ b/wbia/tests/dtool/test_dump.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+import sqlite3
+
+import pytest
+
+from wbia.dtool.dump import dump, dumps
+
+
+@pytest.fixture
+def db_conn():
+    with sqlite3.connect(':memory:') as conn:
+        conn.execute('create table metadata (id int primary key, x text)')
+        conn.execute('create table foo (id int primary key, x text)')
+        conn.execute('create table bar (id int primary key, x text)')
+        for t in ('metadata', 'foo', 'bar'):
+            for i in range(1, 3):
+                conn.execute(
+                    f'insert into {t} (id, x) values (?, ?)', (i, f'_{i}_'),
+                )
+        yield conn
+
+
+def test_dumps(db_conn):
+    # Write some stuff to dump
+    data = dumps(db_conn)
+
+    # Check schema is there
+    assert 'CREATE TABLE bar' in data
+    assert 'CREATE TABLE foo' in data
+    assert 'CREATE TABLE metadata' in data
+
+    # Check data inserts are there
+    assert 'INSERT INTO "metadata" VALUES(1,\'_1_\');' in data
+
+
+def test_dumps_schema_only(db_conn):
+    # Write some stuff to dump
+    data = dumps(db_conn, schema_only=True)
+
+    # Check schema is there
+    assert 'CREATE TABLE bar' in data
+    assert 'CREATE TABLE foo' in data
+    assert 'CREATE TABLE metadata' in data
+
+    # Check data inserts are there
+    assert 'INSERT INTO "foo" VALUES(1,\'_1_\');' not in data
+    assert 'INSERT INTO "bar" VALUES(1,\'_1_\');' not in data
+    # Check metadata inserts are there
+    assert 'INSERT INTO "metadata" VALUES(1,\'_1_\');' in data
+
+
+def test_dump(db_conn, tmp_path):
+    fpath = tmp_path / 'dump.sql'
+    with fpath.open('w') as fp:
+        dump(db_conn, fp)
+
+    with fpath.open('r') as fp:
+        data = fp.read()
+
+    # Check schema is there
+    assert 'CREATE TABLE bar' in data
+    assert 'CREATE TABLE foo' in data
+    assert 'CREATE TABLE metadata' in data
+
+    # Check data inserts are there
+    assert 'INSERT INTO "foo" VALUES(1,\'_1_\');' in data
+    assert 'INSERT INTO "bar" VALUES(1,\'_1_\');' in data
+    # Check data inserts are there
+    assert 'INSERT INTO "metadata" VALUES(1,\'_1_\');' in data


### PR DESCRIPTION
This lifts the dumping procedure out of the class of generalized
use. It also greatly simplifies it (and from what I can tell, fixes
the `include_metadata` behavior).

I've gone with the dump/load serialization convention (e.g. used in
`json` and other apis).

I've choose to drop the argument flag in favor of including the
metadata. This is because including the metadata isn't going to hurt
anything and it's pretty core to this project's way of doing things
anyhow.

---

This also tacks on a commit to remove some no-op code.