### PR TITLE
Override xdoctest_namespaces to add set_up_db fixture

### DIFF
--- a/wbia/tests/conftest.py
+++ b/wbia/tests/conftest.py
@@ -55,3 +55,11 @@ def set_up_db():
     default_db_dir = workdir / 'testdb1'
     # FIXME (16-Jul-12020) Set this only for the test session
     set_default_dbdir(default_db_dir.resolve())
+
+
+@pytest.fixture(scope='session')
+def xdoctest_namespace(set_up_db):
+    """
+    Inject names into the xdoctest namespace.
+    """
+    return dict()


### PR DESCRIPTION
The `xdoctest_namespace` defined by xdoctest for use within pytest is
overwritten to add the loading of our `set_up_db` fixture. This will
effectively load the databases prior to running the discovered
xdoctests.

I was under the belief this was previously taken care by simply
defining the `set_up_db` fixture, which appeared to be running during
the tests. It was running, but falsely. It just so happened that the
collected pytests were running prior to the collected
xdoctests. Recent changes have adjusted the order of execution, causing the
fixture to not run until later when the collected pytests are
executed.

Note, the `xdoctest_namespaces` fixture is present to be overwritten
by the users of xdoctest. It's a common practice when writting a
pytest plugin.