### PR TITLE
Use pytest as the standard pathway/entry-point for testing

### DIFF
--- a/wbia/__init__.py
+++ b/wbia/__init__.py
@@ -383,14 +383,3 @@ Regen Command:
     makeinit.py -x web viz tests gui
     makeinit.py -x constants params main_module other control dbio tests
 """
-
-if __name__ == '__main__':
-    """
-    Runs the unittests for the wbia codebase
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    from wbia.tests.run_tests import run_tests
-
-    run_tests()

--- a/wbia/__main__.py
+++ b/wbia/__main__.py
@@ -80,13 +80,6 @@ def run_wbia():
         print('... exiting')
         sys.exit(0)
 
-    # if ub.argflag('-e'):
-    #    import wbia
-    #    expt_kw = ut.get_arg_dict(ut.get_func_kwargs(wbia.run_experiment),
-    #    prefix_list=['--', '-'])
-    #    wbia.run_experiment(**expt_kw)
-    #    sys.exit(0)
-
     import wbia
 
     main_locals = wbia.main()

--- a/wbia/__main__.py
+++ b/wbia/__main__.py
@@ -67,16 +67,7 @@ def run_wbia():
     if ub.argflag('--devcmd'):
         # Hack to let devs mess around when using an installer version
         # TODO: add more hacks
-        # import utool.tests.run_tests
-        # utool.tests.run_tests.run_tests()
         ut.embed()
-    # Run the tests of other modules
-    elif ub.argflag('--run-utool-tests'):
-        raise Exception('Deprecated functionality')
-    elif ub.argflag('--run-vtool-tests'):
-        raise Exception('Deprecated functionality')
-    elif ub.argflag(('--run-wbia-tests', '--run-tests')):
-        raise Exception('Deprecated functionality')
 
     if ub.argflag('-e'):
         """
@@ -89,57 +80,12 @@ def run_wbia():
         print('... exiting')
         sys.exit(0)
 
-    # Attempt to run a test using the funciton name alone
-    # with the --tf flag
-    # if False:
-    #     import wbia.tests.run_tests
-    #     import wbia.tests.reset_testdbs
-    #     import wbia.scripts.thesis
-    #     ignore_prefix = [
-    #         #'wbia.tests',
-    #         'wbia.control.__SQLITE3__',
-    #         '_autogen_explicit_controller']
-    #     ignore_suffix = ['_grave']
-    #     func_to_module_dict = {
-    #         'demo_bayesnet': 'wbia.unstable.demobayes',
-    #     }
-    #     ut.main_function_tester('wbia', ignore_prefix, ignore_suffix,
-    #                             func_to_module_dict=func_to_module_dict)
-
     # if ub.argflag('-e'):
     #    import wbia
     #    expt_kw = ut.get_arg_dict(ut.get_func_kwargs(wbia.run_experiment),
     #    prefix_list=['--', '-'])
     #    wbia.run_experiment(**expt_kw)
     #    sys.exit(0)
-
-    doctest_modname = ut.get_argval(
-        ('--doctest-module', '--tmod', '-tm', '--testmod'),
-        type_=str,
-        default=None,
-        help_='specify a module to doctest',
-    )
-    if doctest_modname is not None:
-        """
-        Allow any doctest to be run the main wbia script
-
-        python -m wbia --tmod utool.util_str --test-align:0
-        python -m wbia --tmod wbia.algo.hots.pipeline --test-request_wbia_query_L0:0 --show
-        python -m wbia --tf request_wbia_query_L0:0 --show
-        ./dist/wbia/IBEISApp --tmod wbia.algo.hots.pipeline --test-request_wbia_query_L0:0 --show  # NOQA
-        ./dist/wbia/IBEISApp --tmod utool.util_str --test-align:0
-        ./dist/IBEIS.app/Contents/MacOS/IBEISApp --tmod utool.util_str --test-align:0
-        ./dist/IBEIS.app/Contents/MacOS/IBEISApp --run-utool-tests
-        ./dist/IBEIS.app/Contents/MacOS/IBEISApp --run-vtool-tests
-        """
-        print('[wbia] Testing module')
-        mod_alias_list = {'exptdraw': 'wbia.expt.experiment_drawing'}
-        doctest_modname = mod_alias_list.get(doctest_modname, doctest_modname)
-        module = ut.import_modname(doctest_modname)
-        (nPass, nTotal, failed_list, error_report_list) = ut.doctest_funcs(module=module)
-        retcode = 1 - (len(failed_list) == 0)
-        # print(module)
-        sys.exit(retcode)
 
     import wbia
 

--- a/wbia/__main__.py
+++ b/wbia/__main__.py
@@ -9,6 +9,11 @@ import utool as ut
 import ubelt as ub
 import sys
 
+from wbia.dev import devmain
+from wbia.main_module import main, main_loop
+from wbia.scripts.rsync_wbiadb import rsync_ibsdb_main
+
+
 (print, rrr, profile) = ut.inject2(__name__)
 
 CMD = ub.argflag('--cmd')
@@ -35,13 +40,13 @@ def dependencies_for_myprogram():
     importlib.import_module('mpl_toolkits').__path__
 
 
-def main():  # nocover
-    import wbia
+# def main():  # nocover
+#     import wbia
 
-    print('Looks like the imports worked')
-    print('wbia = {!r}'.format(wbia))
-    print('wbia.__file__ = {!r}'.format(wbia.__file__))
-    print('wbia.__version__ = {!r}'.format(wbia.__version__))
+#     print('Looks like the imports worked')
+#     print('wbia = {!r}'.format(wbia))
+#     print('wbia.__file__ = {!r}'.format(wbia.__file__))
+#     print('wbia.__version__ = {!r}'.format(wbia.__version__))
 
 
 def run_wbia():
@@ -59,9 +64,7 @@ def run_wbia():
     # ut.set_process_title('wbia_main')
     cmdline_varags = ut.get_cmdline_varargs()
     if len(cmdline_varags) > 0 and cmdline_varags[0] == 'rsync':
-        from wbia.scripts import rsync_wbiadb
-
-        rsync_wbiadb.rsync_ibsdb_main()
+        rsync_ibsdb_main()
         sys.exit(0)
 
     if ub.argflag('--devcmd'):
@@ -74,16 +77,13 @@ def run_wbia():
         wbia -e print -a default -t default
         """
         # Run dev script if -e given
-        import wbia.dev  # NOQA
 
-        wbia.dev.devmain()
+        devmain()
         print('... exiting')
         sys.exit(0)
 
-    import wbia
-
-    main_locals = wbia.main()
-    execstr = wbia.main_loop(main_locals)
+    main_locals = main()
+    execstr = main_loop(main_locals)
     # <DEBUG CODE>
     if 'back' in main_locals and CMD:
         back = main_locals['back']

--- a/wbia/_wbia_object.py
+++ b/wbia/_wbia_object.py
@@ -608,17 +608,3 @@ class ObjectView1D(ut.NiceRepr):
             childview = self.__class__([rowids], obj1d=self._obj1d, cache=self._cache)
             childview = ObjectScalar0D(childview)
         return childview
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia._wbia_object
-        python -m wbia._wbia_object --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/Config.py
+++ b/wbia/algo/Config.py
@@ -1139,17 +1139,3 @@ def _default_named_config(cfg, cfgname):
     else:
         if ut.VERBOSE:
             print('WARNING: UNKNOWN CFGNAME=%r' % (cfgname,))
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.Config
-        python -m wbia.algo.Config --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/detect/grabmodels.py
+++ b/wbia/algo/detect/grabmodels.py
@@ -130,21 +130,3 @@ def _download_model(algo, algo_modeldir):
     ut.unzip_file(zip_fpath)
     # Cleanup
     ut.delete(zip_fpath)
-
-
-if __name__ == '__main__':
-    """
-
-    modeldir = ibs.get_detect_modeldir()
-
-    CommandLine:
-        python -m wbia.algo.detect.grabmodels
-        python -m wbia.algo.detect.grabmodels --allexamples
-        python -m wbia.algo.detect.grabmodels --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/core.py
+++ b/wbia/algo/graph/core.py
@@ -1505,21 +1505,3 @@ def testdata_infr(defaultdb='PZ_MTEST'):
     aids = [1, 2, 3, 4, 5, 6]
     infr = AnnotInference(ibs, aids, autoinit=True)
     return infr
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.viz.viz_graph2 make_qt_graph_interface --show --aids=1,2,3,4,5,6,7 --graph --match=1,4 --nomatch=3,1,5,7
-        python -m wbia.algo.graph.core
-
-        python -m wbia.algo.graph all
-
-        python -m wbia.algo.graph.core --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/demo.py
+++ b/wbia/algo/graph/demo.py
@@ -887,20 +887,3 @@ class DummyVerif(object):
     def predict_edges(verif, edges):
         pos_scores = verif.predict_proba_df(edges)[POSTV]
         return pos_scores
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        wbia make_qt_graph_interface --show --aids=1,2,3,4,5,6,7 --graph
-        python -m wbia.algo.graph.demo demo2
-        python -m wbia.algo.graph.demo
-        python -m wbia.algo.graph.demo --allexamples
-        python -m wbia.algo.graph.demo --allexamples --show
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_dynamic.py
+++ b/wbia/algo/graph/mixin_dynamic.py
@@ -1529,17 +1529,3 @@ class NonDynamicUpdate(object):
             'inconsistent_external': incon_external,
         }
         return ne_categories
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_dynamic
-        python -m wbia.algo.graph.mixin_dynamic --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_helpers.py
+++ b/wbia/algo/graph/mixin_helpers.py
@@ -768,17 +768,3 @@ class AssertInvariants(object):
         #         #     map(pos_graph.node_label, incon_cc))
         #         infr.print('infr.recovery_cc = %r' % (infr.recovery_cc,))
         #         infr.print('incon_cc = %r' % (incon_cc,))
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_helpers
-        python -m wbia.algo.graph.mixin_helpers --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_loops.py
+++ b/wbia/algo/graph/mixin_loops.py
@@ -776,17 +776,3 @@ if False:
             return item
 
         next = __next__
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_loops
-        python -m wbia.algo.graph.mixin_loops --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_matching.py
+++ b/wbia/algo/graph/mixin_matching.py
@@ -1058,17 +1058,3 @@ class CandidateSearch(_RedundancyAugmentation):
         # take the inf-norm
         normscores = edge_scores / vt.safe_max(edge_scores, nans=False)
         return normscores
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_matching
-        python -m wbia.algo.graph.mixin_matching --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_priority.py
+++ b/wbia/algo/graph/mixin_priority.py
@@ -535,17 +535,3 @@ class Priority(object):
             while True:
                 edge, priority = infr.pop()
                 yield edge
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_priority
-        python -m wbia.algo.graph.mixin_priority --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_simulation.py
+++ b/wbia/algo/graph/mixin_simulation.py
@@ -487,17 +487,3 @@ class UserOracle(object):
             #     'ORACLE ERROR edge={}, truth={}, pred={}, rec={}, hardness={:.3f}'.format(edge, truth, observed, is_recovering, hardness),
             #     2, color='red')
         return feedback
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_simulation
-        python -m wbia.algo.graph.mixin_simulation --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_viz.py
+++ b/wbia/algo/graph/mixin_viz.py
@@ -926,17 +926,3 @@ def on_pick(event, infr=None):
         else:
             print('???: ' + ut.repr2(plotdat))
     print(ut.get_timestamp())
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_viz
-        python -m wbia.algo.graph.mixin_viz --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/mixin_wbia.py
+++ b/wbia/algo/graph/mixin_wbia.py
@@ -1275,17 +1275,3 @@ def needs_conversion(infr):
     num_names = len(set(infr.get_node_attrs('name_label').values()))
     num_pccs = infr.pos_graph.number_of_components()
     return num_pccs == 0 and num_names > 0
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.mixin_wbia
-        python -m wbia.algo.graph.mixin_wbia --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/nx_dynamic_graph.py
+++ b/wbia/algo/graph/nx_dynamic_graph.py
@@ -386,18 +386,3 @@ class DynConnGraph(nx.Graph, GraphHelperMixin):
             for u, v in H.edges():
                 H._union(u, v)
         return H
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph all
-        python -m wbia.algo.graph.nx_dynamic_graph all
-        python -m wbia.algo.graph.nx_dynamic_graph --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/nx_utils.py
+++ b/wbia/algo/graph/nx_utils.py
@@ -453,17 +453,3 @@ def edge_df(graph, edges, ignore=None):
         except Exception:
             pass
     return df
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.nx_utils
-        python -m wbia.algo.graph.nx_utils --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/refresh.py
+++ b/wbia/algo/graph/refresh.py
@@ -666,17 +666,3 @@ def _dev_iters_until_threshold():
     for target, dat in target_binom_plots.items():
         slope = np.median(np.diff(dat[1]))
         aval = int(np.ceil(sval * slope))
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.refresh
-        python -m wbia.algo.graph.refresh --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/tests/dyn_cases.py
+++ b/wbia/algo/graph/tests/dyn_cases.py
@@ -693,17 +693,3 @@ def case_all_types():
     # check(infr2, 2, 4, 'maybe_error', True, 'negative edge should flag second')
     # check(infr2, 1, 4, 'maybe_error', False, 'negative edge should flag second')
     check.after(errors)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.graph.tests.dyn_cases
-        python -m wbia.algo.graph.tests.dyn_cases --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/graph/tests/test_graph_iden.py
+++ b/wbia/algo/graph/tests/test_graph_iden.py
@@ -137,21 +137,3 @@ def _test_pos_neg():
     infr.add_feedback((1, 11), NEGTV)
     print('Final state:')
     print(ut.repr4(sorted(infr.gen_edge_attrs('decision'))))
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        export PYTHONPATH=$PYTHONPATH:/home/joncrall/code/wbia/wbia/algo/graph/tests
-        python ~/code/wbia/wbia/algo/graph/tests/test_graph_iden.py test_pos_neg
-        python ~/code/wbia/wbia/algo/graph/tests/test_graph_iden.py test_unrev_inference
-        python ~/code/wbia/wbia/algo/graph/tests/test_graph_iden.py test_incomp_inference
-        python ~/code/wbia/wbia/algo/graph/tests/test_graph_iden.py --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()
-    # import ubelt as ub

--- a/wbia/algo/hots/_pipeline_helpers.py
+++ b/wbia/algo/hots/_pipeline_helpers.py
@@ -240,18 +240,3 @@ def testdata_post_sver(
 
 
 # L_______
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots._pipeline_helpers
-        python -m wbia.algo.hots._pipeline_helpers --allexamples
-        python -m wbia.algo.hots._pipeline_helpers --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/chip_match.py
+++ b/wbia/algo/hots/chip_match.py
@@ -3014,18 +3014,3 @@ def get_chipmatch_fname(
         fname_fmt, fmt_dict, ['cfgstr'], max_len=MAX_FNAME_LEN, hack27=True
     )
     return fname
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.chip_match
-        python -m wbia.algo.hots.chip_match --allexamples
-        python -m wbia.algo.hots.chip_match --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/hstypes.py
+++ b/wbia/algo/hots/hstypes.py
@@ -134,18 +134,3 @@ WEIGHT_FILTERS = [FiltKeys.FG, FiltKeys.DISTINCTIVENESS, FiltKeys.HOMOGERR]
 
 # Replace old cmtup_old with ducktype
 # Keep this turned off for now until we actually start using it
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.hstypes
-        python -m wbia.algo.hots.hstypes --allexamples
-        python -m wbia.algo.hots.hstypes --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/match_chips4.py
+++ b/wbia/algo/hots/match_chips4.py
@@ -395,14 +395,3 @@ def execute_query2(qreq_, verbose, save_qcache, batch_size=None, use_supercache=
                 print('[mc4] not saving vsmany chunk')
         qaid2_cm.update({cm.qaid: cm for cm in sub_cm_list})
     return qaid2_cm
-
-
-if __name__ == '__main__':
-    """
-    python -m wbia.algo.hots.match_chips4
-    python -m wbia.algo.hots.match_chips4 --allexamples --testslow
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    ut.doctest_funcs()

--- a/wbia/algo/hots/name_scoring.py
+++ b/wbia/algo/hots/name_scoring.py
@@ -401,18 +401,3 @@ def align_name_scores_with_annots(
         # nid_list (which should be == cm.unique_nids)
         score_list[best_idx_list] = name_score_list
         return score_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.name_scoring
-        python -m wbia.algo.hots.name_scoring --allexamples
-        python -m wbia.algo.hots.name_scoring --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/neighbor_index.py
+++ b/wbia/algo/hots/neighbor_index.py
@@ -1095,16 +1095,3 @@ def testdata_nnindexer(*args, **kwargs):
     from wbia.algo.hots.neighbor_index_cache import testdata_nnindexer
 
     return testdata_nnindexer(*args, **kwargs)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.neighbor_index
-        python -m wbia.algo.hots.neighbor_index --allexamples
-        utprof.sh wbia/algo/hots/neighbor_index.py --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/algo/hots/neighbor_index_cache.py
+++ b/wbia/algo/hots/neighbor_index_cache.py
@@ -889,17 +889,3 @@ def background_flann_func(
     if len(visual_uuid_list) > min_reindex_thresh:
         UUID_MAP_CACHE.write_uuid_map_dict(uuid_map_fpath, visual_uuid_list, daids_hashid)
     print('[BG] Finished Background FLANN')
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.hots.neighbor_index_cache
-        python -m wbia.algo.hots.neighbor_index_cache --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/nn_weights.py
+++ b/wbia/algo/hots/nn_weights.py
@@ -666,16 +666,3 @@ def all_normalized_weights_test():
         if normweight_key not in nn_weights.__dict__:
             continue
         tst_weight_fn(nn_weight, nns_list, qreq_, qaid)
-
-
-if __name__ == '__main__':
-    r"""
-    python -m wbia.algo.hots.nn_weights --allexamples
-    python -m wbia.algo.hots.nn_weights
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/pipeline.py
+++ b/wbia/algo/hots/pipeline.py
@@ -1618,23 +1618,3 @@ def compute_matching_dlen_extent(qreq_, fm_list, kpts_list):
     # [kpts.take(fx2, axis=0) for (kpts, fx2) in zip(kpts_list, fx2_list)]
     dlen_sqrd_list = [vt.get_kpts_dlen_sqrd(kpts2_m) for kpts2_m in kpts2_m_list]
     return dlen_sqrd_list
-
-
-if __name__ == '__main__':
-    """
-    python -m wbia.algo.hots.pipeline --verb-test
-    python -m wbia.algo.hots.pipeline --test-build_chipmatches
-    python -m wbia.algo.hots.pipeline --test-spatial-verification
-    python -m wbia.algo.hots.pipeline --test-request_wbia_query_L0 --show
-    python -m wbia.algo.hots.pipeline --test-request_wbia_query_L0:0 --show
-    python -m wbia.algo.hots.pipeline --test-request_wbia_query_L0:1 --show --db NAUT_test
-    python -m wbia.algo.hots.pipeline --test-request_wbia_query_L0:1 --db NAUT_test --noindent
-    python -m wbia.algo.hots.pipeline --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    ut.doctest_funcs()
-    # if ut.get_argflag('--show'):
-    #     import wbia.plottool as pt
-    #     exec(pt.present())

--- a/wbia/algo/hots/query_params.py
+++ b/wbia/algo/hots/query_params.py
@@ -149,18 +149,3 @@ class QueryParams(collections.Mapping):
 
     def __setstate__(qparams, state_dict):
         qparams.__dict__.update(state_dict)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.query_params
-        python -m wbia.algo.hots.query_params --allexamples
-        python -m wbia.algo.hots.query_params --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/query_request.py
+++ b/wbia/algo/hots/query_request.py
@@ -1343,17 +1343,3 @@ def cfg_deepcopy_test():
     cfg2.update_query_cfg(sv_on=False)
     assert cfg1.get_cfgstr() != cfg2.get_cfgstr()
     assert cfg2.get_cfgstr() == cfg3.get_cfgstr()
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        utprof.sh -m wbia.algo.hots.query_request --test-QueryParams
-        python -m wbia.algo.hots.query_request
-        python -m wbia.algo.hots.query_request --allexamples
-        python -m wbia.algo.hots.query_request --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/algo/hots/scoring.py
+++ b/wbia/algo/hots/scoring.py
@@ -172,18 +172,3 @@ def make_chipmatch_shortlists(
         cm_subset = cm.shortlist_subset(top_aids)
         cm_shortlist.append(cm_subset)
     return cm_shortlist
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.scoring
-        python -m wbia.algo.hots.scoring --allexamples
-        python -m wbia.algo.hots.scoring --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/hots/tests/bench.py
+++ b/wbia/algo/hots/tests/bench.py
@@ -34,18 +34,3 @@ def benchmark_knn():
     nns_list1 = nearest_neighbors(  # NOQA
         qreq_, Kpad_list, impossible_daids_list, verbose=verbose
     )
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        export PYTHONPATH=$PYTHONPATH:/home/joncrall/code/wbia/wbia/algo/hots/tests
-        python ~/code/wbia/wbia/algo/hots/tests/bench.py
-        python ~/code/wbia/wbia/algo/hots/tests/bench.py --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/preproc/occurrence_blackbox.py
+++ b/wbia/algo/preproc/occurrence_blackbox.py
@@ -602,12 +602,5 @@ if __name__ == '__main__':
     r"""
     CommandLine:
         python -m wbia.algo.preproc.occurrence_blackbox
-        python -m wbia.algo.preproc.occurrence_blackbox --allexamples
     """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    if not ut.doctest_funcs():
-        main()
+    main()

--- a/wbia/algo/preproc/preproc_annot.py
+++ b/wbia/algo/preproc/preproc_annot.py
@@ -140,21 +140,3 @@ def postget_annot_verts(vertstr_list):
     globals_ = {}
     vert_list = [eval(vertstr, globals_, locals_) for vertstr in vertstr_list]
     return vert_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.template_generator --tbls annotations --Tflags getters native
-
-        python -m wbia.algo.preproc.preproc_annot
-        python -m wbia.algo.preproc.preproc_annot --allexamples
-        python -m wbia.algo.preproc.preproc_annot --allexamples --noface --nosrc
-
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/preproc/preproc_image.py
+++ b/wbia/algo/preproc/preproc_image.py
@@ -223,14 +223,3 @@ def parse_imageinfo(gpath):
 
 def on_delete(ibs, featweight_rowid_list, qreq_=None):
     print('Warning: Not Implemented')
-
-
-if __name__ == '__main__':
-    """
-    python -m wbia.algo.preproc.preproc_image
-    python -m wbia.algo.preproc.preproc_image --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    ut.doctest_funcs()

--- a/wbia/algo/preproc/preproc_occurrence.py
+++ b/wbia/algo/preproc/preproc_occurrence.py
@@ -593,15 +593,3 @@ def plot_gps_html(gps_list):
     # fig.zoom_fac = pt.zoom_factory()
     # fig.pan_fac = pt.pan_factory()
     # fig.show()
-
-
-if __name__ == '__main__':
-    """
-    python -m wbia.algo.preproc.preproc_occurrence
-    python -m wbia.algo.preproc.preproc_occurrence --allexamples
-    """
-    import utool as ut
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    ut.doctest_funcs()

--- a/wbia/algo/preproc/preproc_residual.py
+++ b/wbia/algo/preproc/preproc_residual.py
@@ -14,11 +14,3 @@ def add_residual_params_gen(ibs, fid_list, qreq_=None):
 def on_delete(ibs, featweight_rowid_list):
     print('Warning: Not Implemented')
     print('Probably nothing to do here')
-
-
-if __name__ == '__main__':
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    testable_list = []
-    ut.doctest_funcs(testable_list)

--- a/wbia/algo/smk/inverted_index.py
+++ b/wbia/algo/smk/inverted_index.py
@@ -764,17 +764,3 @@ def testdata_inva():
     inva = cls.from_depc(depc, aids, vocab_aids, config)
     inva.wx_to_aids = inva.compute_inverted_list()
     return qreq_, inva
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.smk.inverted_index
-        python -m wbia.algo.smk.inverted_index --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/smk/pickle_flann.py
+++ b/wbia/algo/smk/pickle_flann.py
@@ -154,17 +154,3 @@ if pyflann is not None:
 
 else:
     PickleFLANN = None
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.smk.pickle_flann
-        python -m wbia.algo.smk.pickle_flann --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/smk/smk_funcs.py
+++ b/wbia/algo/smk/smk_funcs.py
@@ -1046,17 +1046,3 @@ def testdata_rvecs(dim=2, nvecs=13, nwords=5, nannots=4):
     }
 
     return data
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.smk.smk_funcs
-        python -m wbia.algo.smk.smk_funcs --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/smk/smk_pipeline.py
+++ b/wbia/algo/smk/smk_pipeline.py
@@ -586,18 +586,3 @@ def testdata_smk(*args, **kwargs):
     # qreq_ = ibs.new_query_request(qaids, daids, cfgdict={'pipeline_root': 'smk', 'proot': 'smk'})
     # qreq_ = ibs.new_query_request(qaids, daids, cfgdict={})
     return ibs, smk, qreq_
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        export PYTHONPATH=$PYTHONPATH:/home/joncrall/code/wbia/wbia/algo/smk
-        python ~/code/wbia/wbia/algo/smk/smk_pipeline.py
-        python ~/code/wbia/wbia/algo/smk/smk_pipeline.py --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/smk/vocab_indexer.py
+++ b/wbia/algo/smk/vocab_indexer.py
@@ -321,18 +321,3 @@ def testdata_vocab(defaultdb='testdb1', **kwargs):
     vocab.config_history = table.get_config_history([vocab.rowid])[0]
     vocab.config = table.get_row_configs([vocab.rowid])[0]
     return vocab
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        export PYTHONPATH=$PYTHONPATH:/home/joncrall/code/wbia/wbia/algo/smk
-        python ~/code/wbia/wbia/algo/smk/vocab_indexer.py
-        python ~/code/wbia/wbia/algo/smk/vocab_indexer.py --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/verif/clf_helpers.py
+++ b/wbia/algo/verif/clf_helpers.py
@@ -1613,17 +1613,3 @@ class IrisProblem(ClfProblem):
 
         pblm.samples = samples
         pblm.xval_kw['type'] = 'StratifiedKFold'
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.verif.samples
-        python -m wbia.algo.verif.samples --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/verif/deploy.py
+++ b/wbia/algo/verif/deploy.py
@@ -480,17 +480,3 @@ class Deployer(object):
             ut.rsync(meta_fpath, remote_uri + '/' + meta_fname)
             ut.rsync(deploy_fpath, remote_uri + '/' + deploy_fname)
         return deploy_info
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.verif.deploy
-        python -m wbia.algo.verif.deploy --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/verif/pairfeat.py
+++ b/wbia/algo/verif/pairfeat.py
@@ -523,17 +523,3 @@ class PairwiseFeatureExtractor(object):
             matches, feats = data
             feats = extr._postprocess_feats(feats)
         return feats
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.verif.pairfeat
-        python -m wbia.algo.verif.pairfeat --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/verif/torch/train_main.py
+++ b/wbia/algo/verif/torch/train_main.py
@@ -212,13 +212,3 @@ class LabeledPairDataset(torch.utils.data.Dataset):
 
     def __len__(self):
         return len(self.img1_fpaths)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.verif.torch.train_main
-    """
-    import xdoctest
-
-    xdoctest.doctest_module(__file__)

--- a/wbia/algo/verif/verifier.py
+++ b/wbia/algo/verif/verifier.py
@@ -211,17 +211,3 @@ class IntraVerifier(BaseVerifier):
 
         probs = pd.concat([have_probs, eclf_probs])
         return probs
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.verif.verifier
-        python -m wbia.algo.verif.verifier --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/algo/verif/vsone.py
+++ b/wbia/algo/verif/vsone.py
@@ -1956,17 +1956,3 @@ class AnnotPairSamples(clf_helpers.MultiTaskSamples, ub.NiceRepr):
             print('\nINFO(samples.X_dict[%s])' % (data_key,))
             featinfo = vt.AnnotPairFeatInfo(samples.X_dict[data_key])
             print(ut.indent(featinfo.get_infostr()))
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.verif.vsone
-        python -m wbia.algo.verif.vsone --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/annotmatch_funcs.py
+++ b/wbia/annotmatch_funcs.py
@@ -744,18 +744,3 @@ def get_match_text(ibs, aid1, aid2):
     truth = ibs.get_match_truth(aid1, aid2)
     text = ibs.const.EVIDENCE_DECISION.INT_TO_NICE.get(truth, None)
     return text
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.annotmatch_funcs
-        python -m wbia.annotmatch_funcs --allexamples
-        python -m wbia.annotmatch_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/annots.py
+++ b/wbia/annots.py
@@ -610,17 +610,3 @@ class AnnotMatches(BASE):
     def evidence_decision_code(self):
         INT_TO_CODE = self._ibs.const.EVIDENCE_DECISION.INT_TO_CODE
         return [INT_TO_CODE[c] for c in self.evidence_decision]
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.annot
-        python -m wbia.annot --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/constants.py
+++ b/wbia/constants.py
@@ -1290,17 +1290,3 @@ class VIEW(object):
     # make distance symmetric
     for (f1, f2), d in list(DIST.items()):
         DIST[(f2, f1)] = d
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.constants
-        python -m wbia.constants --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/DB_SCHEMA.py
+++ b/wbia/control/DB_SCHEMA.py
@@ -2176,16 +2176,3 @@ def dump_schema_sql():
         coldef_list = autogen_dict['coldef_list']
         str_ = db._make_add_table_sqlstr(tablename, coldef_list=coldef_list, sep='\n    ')
         print(str_)
-
-
-if __name__ == '__main__':
-    """
-    python -m wbia.algo.preproc.preproc_chip
-    python -m wbia.control.DB_SCHEMA --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    import utool as ut
-
-    ut.doctest_funcs()

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -1316,23 +1316,3 @@ class IBEISController(BASE_CLASS):
                 continue
 
         return None
-
-
-if __name__ == '__main__':
-    """
-    Issue when running on windows:
-    python wbia/control/IBEISControl.py
-    python -m wbia.control.IBEISControl --verbose --very-verbose --veryverbose --nodyn --quietclass
-
-    CommandLine:
-        python -m wbia.control.IBEISControl
-        python -m wbia.control.IBEISControl --allexamples
-        python -m wbia.control.IBEISControl --allexamples --noface --nosrc
-    """
-    # from wbia.control import IBEISControl
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/STAGING_SCHEMA.py
+++ b/wbia/control/STAGING_SCHEMA.py
@@ -188,16 +188,3 @@ def autogen_staging_schema():
     schema_spec = STAGING_SCHEMA
     db = _sql_helpers.autogenerate_nth_schema_version(schema_spec, n=n)
     return db
-
-
-if __name__ == '__main__':
-    """
-    python -m wbia.algo.preproc.preproc_chip
-    python -m wbia.control.STAGING_SCHEMA --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    import utool as ut
-
-    ut.doctest_funcs()

--- a/wbia/control/_autogen_party_funcs.py
+++ b/wbia/control/_autogen_party_funcs.py
@@ -171,17 +171,3 @@ def get_party_tag(ibs, party_rowid_list, eager=True, nInput=None):
         nInput=nInput,
     )
     return party_tag_list
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control._autogen_party_funcs
-        python -m wbia.control._autogen_party_funcs --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    import utool as ut
-
-    ut.doctest_funcs()

--- a/wbia/control/_sql_helpers.py
+++ b/wbia/control/_sql_helpers.py
@@ -535,18 +535,3 @@ def get_nth_test_schema_version(schema_spec, n=-1):
     db = SQLDatabaseController(cachedir, db_fname)
     ensure_correct_version(None, db, version_expected, schema_spec, dobackup=False)
     return db
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control._sql_helpers
-        python -m wbia.control._sql_helpers --allexamples
-        python -m wbia.control._sql_helpers --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/accessor_decors.py
+++ b/wbia/control/accessor_decors.py
@@ -535,17 +535,3 @@ def ider(func):
     """ This function takes returns ids subject to conditions """
     ider_func = ut.preserve_sig(func, func)
     return ider_func
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.accessor_decors
-        python -m wbia.control.accessor_decors --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/controller_inject.py
+++ b/wbia/control/controller_inject.py
@@ -1387,18 +1387,3 @@ register_subprops = {
     'annot': _decors_annot['subprop'],
     'part': _decors_part['subprop'],
 }
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.controller_inject
-        python -m wbia.control.controller_inject --allexamples
-        python -m wbia.control.controller_inject --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/docker_control.py
+++ b/wbia/control/docker_control.py
@@ -355,16 +355,3 @@ def docker_get_config(ibs, container_name):
 # @register_ibs_method
 # def docker_embed(ibs):
 #     ut.embed()
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.docker_control --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_annot_funcs.py
+++ b/wbia/control/manual_annot_funcs.py
@@ -4474,18 +4474,3 @@ def testdata_ibs():
     ibs = wbia.opendb('testdb1')
     qreq_ = None
     return ibs, qreq_
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_annot_funcs
-        python -m wbia.control.manual_annot_funcs --allexamples
-        python -m wbia.control.manual_annot_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_annotgroup_funcs.py
+++ b/wbia/control/manual_annotgroup_funcs.py
@@ -372,17 +372,3 @@ def set_annotgroup_uuid(
         id_iter,
         duplicate_behavior=duplicate_behavior,
     )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_annotgroup_funcs
-        python -m wbia.control.manual_annotgroup_funcs --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    import utool as ut
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_annotmatch_funcs.py
+++ b/wbia/control/manual_annotmatch_funcs.py
@@ -727,13 +727,3 @@ def set_annotmatch_count(
         id_iter,
         duplicate_behavior=duplicate_behavior,
     )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        xdoctest -m wbia.control.manual_annotmatch_funcs
-    """
-    import xdoctest
-
-    xdoctest.doctest_module(__file__)

--- a/wbia/control/manual_chip_funcs.py
+++ b/wbia/control/manual_chip_funcs.py
@@ -385,18 +385,3 @@ def testdata_ibs():
     ibs = wbia.opendb('testdb1')
     config2_ = None
     return ibs, config2_
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_chip_funcs
-        python -m wbia.control.manual_chip_funcs --allexamples
-        python -m wbia.control.manual_chip_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_feat_funcs.py
+++ b/wbia/control/manual_feat_funcs.py
@@ -233,18 +233,3 @@ def testdata_ibs():
     ibs = wbia.opendb('testdb1')
     config2_ = None
     return ibs, config2_
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_feat_funcs
-        python -m wbia.control.manual_feat_funcs --allexamples
-        python -m wbia.control.manual_feat_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_featweight_funcs.py
+++ b/wbia/control/manual_featweight_funcs.py
@@ -57,17 +57,3 @@ def get_annot_fgweight_rowids(ibs, aid_list, config2_=None, ensure=True):
     """
     fgw_rowid_list = ibs.depc_annot.get_rowids('featweight', aid_list, config=config2_)
     return fgw_rowid_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_featweight_funcs
-        python -m wbia.control.manual_featweight_funcs --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    import utool as ut
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_garelate_funcs.py
+++ b/wbia/control/manual_garelate_funcs.py
@@ -248,17 +248,3 @@ def get_gar_rowid_from_superkey(
         nInput=nInput,
     )
     return gar_rowid_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_garelate_funcs
-        python -m wbia.control.manual_garelate_funcs --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    import utool as ut
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_gsgrelate_funcs.py
+++ b/wbia/control/manual_gsgrelate_funcs.py
@@ -209,18 +209,3 @@ def add_image_relationship(ibs, gid_list, imgsetid_list):
         superkey_paramx,
     )
     return gsgrid_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_gsgrelate_funcs
-        python -m wbia.control.manual_gsgrelate_funcs --allexamples
-        python -m wbia.control.manual_gsgrelate_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_image_funcs.py
+++ b/wbia/control/manual_image_funcs.py
@@ -2897,18 +2897,3 @@ def testdata_ibs():
     ibs = wbia.opendb('testdb1')
     config2_ = None
     return ibs, config2_
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_image_funcs
-        python -m wbia.control.manual_image_funcs --allexamples
-        python -m wbia.control.manual_image_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_imageset_funcs.py
+++ b/wbia/control/manual_imageset_funcs.py
@@ -1642,18 +1642,3 @@ def testdata_ibs():
     ibs = wbia.opendb('testdb1')
     config2_ = None
     return ibs, config2_
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_imageset_funcs
-        python -m wbia.control.manual_imageset_funcs --allexamples
-        python -m wbia.control.manual_imageset_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_lblannot_funcs.py
+++ b/wbia/control/manual_lblannot_funcs.py
@@ -500,18 +500,3 @@ def get_annot_lblannot_rowids_oftype(ibs, aid_list, _lbltype=None):
     alrids_list = ibs.get_annot_alrids_oftype(aid_list, ibs.lbltype_ids[_lbltype])
     lblannot_rowids_list = ibsfuncs.unflat_map(ibs.get_alr_lblannot_rowids, alrids_list)
     return lblannot_rowids_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_lblannot_funcs
-        python -m wbia.control.manual_lblannot_funcs --allexamples
-        python -m wbia.control.manual_lblannot_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_lblimage_funcs.py
+++ b/wbia/control/manual_lblimage_funcs.py
@@ -250,18 +250,3 @@ def get_image_glrids(ibs, gid_list):
         unpack_scalars=False,
     )
     return glrids_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_lblimage_funcs
-        python -m wbia.control.manual_lblimage_funcs --allexamples
-        python -m wbia.control.manual_lblimage_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_lbltype_funcs.py
+++ b/wbia/control/manual_lbltype_funcs.py
@@ -77,18 +77,3 @@ def get_lbltype_text(ibs, lbltype_rowid_list):
         const.LBLTYPE_TABLE, ('lbltype_text',), lbltype_rowid_list
     )
     return lbltype_text_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_lbltype_funcs
-        python -m wbia.control.manual_lbltype_funcs --allexamples
-        python -m wbia.control.manual_lbltype_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_meta_funcs.py
+++ b/wbia/control/manual_meta_funcs.py
@@ -1119,18 +1119,3 @@ def update_query_cfg(ibs, **kwargs):
     """
     Config.update_query_config(ibs.cfg, **kwargs)
     ibs.reset_table_cache()
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_meta_funcs
-        python -m wbia.control.manual_meta_funcs --allexamples
-        python -m wbia.control.manual_meta_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_name_funcs.py
+++ b/wbia/control/manual_name_funcs.py
@@ -1629,19 +1629,3 @@ def get_name_gps_tracks(ibs, nid_list=None, aid_list=None):
         ut.compress(aids, isvalids) for aids, isvalids in zip(aids_list, isvalids_list)
     ]
     return nid_list, gps_track_list, aid_track_list
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_name_funcs
-        python -m wbia.control.manual_name_funcs --allexamples
-
-        python -m wbia.control.manual_name_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_part_funcs.py
+++ b/wbia/control/manual_part_funcs.py
@@ -1496,18 +1496,3 @@ def testdata_ibs():
     ibs = wbia.opendb('testdb1')
     qreq_ = None
     return ibs, qreq_
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_part_funcs
-        python -m wbia.control.manual_part_funcs --allexamples
-        python -m wbia.control.manual_part_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_review_funcs.py
+++ b/wbia/control/manual_review_funcs.py
@@ -981,18 +981,3 @@ def set_review_metadata(ibs, review_rowid_list, metadata_dict_list):
         metadata_str_list.append(metadata_str)
     val_list = ((metadata_str,) for metadata_str in metadata_str_list)
     ibs.staging.set(const.REVIEW_TABLE, ('review_metadata_json',), val_list, id_iter)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_review_funcs
-        python -m wbia.control.manual_review_funcs --allexamples
-        python -m wbia.control.manual_review_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_species_funcs.py
+++ b/wbia/control/manual_species_funcs.py
@@ -632,18 +632,3 @@ def set_species_enabled(ibs, species_rowid_list, enabled_list):
     id_iter = ((species_rowid,) for species_rowid in species_rowid_list)
     val_list = ((enabled,) for enabled in enabled_list)
     ibs.db.set(const.SPECIES_TABLE, (SPECIES_ENABLED,), val_list, id_iter)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_species_funcs
-        python -m wbia.control.manual_species_funcs --allexamples
-        python -m wbia.control.manual_species_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_test_funcs.py
+++ b/wbia/control/manual_test_funcs.py
@@ -135,18 +135,3 @@ def delete_test(ibs, test_rowid_list):
 def get_test_uuid(ibs, test_rowid_list):
     test_uuid_list = ibs.staging.get(const.TEST_TABLE, (TEST_UUID,), test_rowid_list)
     return test_uuid_list
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.manual_test_funcs
-        python -m wbia.control.manual_test_funcs --allexamples
-        python -m wbia.control.manual_test_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_wbiacontrol_funcs.py
+++ b/wbia/control/manual_wbiacontrol_funcs.py
@@ -139,18 +139,3 @@ def show_annot_image(ibs, aid, *args, **kwargs):
 
     gid = ibs.get_annot_gids(aid)
     return viz_image.show_image(ibs, gid, *args, **kwargs)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_wbiacontrol_funcs
-        python -m wbia.control.manual_wbiacontrol_funcs --allexamples
-        python -m wbia.control.manual_wbiacontrol_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/manual_wildbook_funcs.py
+++ b/wbia/control/manual_wildbook_funcs.py
@@ -760,18 +760,3 @@ def flukebook_sync(ibs, **kwargs):
         'species_update': update_dict,
     }
     return result_dict
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.control.manual_wildbook_funcs
-        python -m wbia.control.manual_wildbook_funcs --allexamples
-        python -m wbia.control.manual_wildbook_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/control/wildbook_manager.py
+++ b/wbia/control/wildbook_manager.py
@@ -806,17 +806,3 @@ def get_wildbook_tomcat_path(ibs, tomcat_dpath=None, wb_target=None):
     wb_target = ibs.const.WILDBOOK_TARGET if wb_target is None else wb_target
     wildbook_tomcat_path = join(tomcat_dpath, 'webapps', wb_target)
     return wildbook_tomcat_path
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.control.wildbook_manager
-        python -m wbia.control.wildbook_manager --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/core_annots.py
+++ b/wbia/core_annots.py
@@ -2263,18 +2263,3 @@ def compute_orients_annotations(depc, aid_list, config=None):
     # yield detections
     for result in result_gen:
         yield result
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.core_annots
-        python -m wbia.core_annots --allexamples
-        utprof.py -m wbia.core_annots --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/core_images.py
+++ b/wbia/core_images.py
@@ -2532,17 +2532,3 @@ def compute_cameratrap_exif_worker(
         raw = None
 
     return raw
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.core_images
-        python -m wbia.core_images --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/core_parts.py
+++ b/wbia/core_parts.py
@@ -82,18 +82,3 @@ def compute_part_chip(depc, part_rowid_list, config=None):
     for result in result_list:
         yield result
     print('Done Preprocessing Part Chips')
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.core_parts
-        python -m wbia.core_parts --allexamples
-        utprof.py -m wbia.core_parts --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dbio/export_hsdb.py
+++ b/wbia/dbio/export_hsdb.py
@@ -252,18 +252,3 @@ def dump_hots_flat_table(ibs):
 
 
 SUCCESS_FLAG_FNAME = '_hsdb_to_ibeis_convert_success'
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.dbio.export_hsdb
-        python -m wbia.dbio.export_hsdb --allexamples
-        python -m wbia.dbio.export_hsdb --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dbio/export_subset.py
+++ b/wbia/dbio/export_subset.py
@@ -1254,14 +1254,3 @@ def MERGE_NNP_MASTER_SCRIPT():
     #print(ibs2.get_image_time_statstr())
     #print(ibs3.get_image_time_statstr())
 """
-
-
-if __name__ == '__main__':
-    """
-    python -m wbia.dbio.export_subset
-    python -m wbia.dbio.export_subset --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()
-    ut.doctest_funcs()

--- a/wbia/dbio/ingest_database.py
+++ b/wbia/dbio/ingest_database.py
@@ -1855,13 +1855,3 @@ def injest_main():
     # main_locals = wbia.main(dbdir=img_dir, gui=False)
     # ibs = main_locals['ibs']
     # ingest_rawdata(ibs, img_dir)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        xdoctest -m wbia.dbio.ingest_database
-    """
-    import xdoctest
-
-    xdoctest.doctest_module(__file__)

--- a/wbia/dbio/ingest_hsdb.py
+++ b/wbia/dbio/ingest_hsdb.py
@@ -386,18 +386,3 @@ def convert_hsdb_to_wbia(hsdir, dbdir=None, **kwargs):
         file_.write('Successfully converted hsdir=%r' % (hsdir,))
     print('finished ingest')
     return ibs
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.dbio.ingest_hsdb
-        python -m wbia.dbio.ingest_hsdb --allexamples
-        python -m wbia.dbio.ingest_hsdb --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dtool/base.py
+++ b/wbia/dtool/base.py
@@ -1138,17 +1138,3 @@ class MatchResult(AlgoResult, ut.NiceRepr):
 
     def __nice__(cm):
         return ' qaid=%s nD=%s' % (cm.qaid, cm.num_daids)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m dtool.base
-        python -m dtool.base --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dtool/depcache_control.py
+++ b/wbia/dtool/depcache_control.py
@@ -1674,17 +1674,3 @@ class DependencyCache(_CoreDependencyCache, ut.NiceRepr):
         # cfgstr = stacked_config.get_cfgstr()
         # cfgstr = '_'.join(cfgstr_list)
         # return cfgstr
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m dtool.depcache_control
-        python -m dtool.depcache_control --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dtool/depcache_table.py
+++ b/wbia/dtool/depcache_table.py
@@ -2987,17 +2987,3 @@ class DependencyCacheTable(
 
         table.db.cur.execute('SELECT * FROM {tablename} WHERE rowid=?')
         pass
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m dtool.depcache_table
-        python -m dtool.depcache_table --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dtool/example_depcache.py
+++ b/wbia/dtool/example_depcache.py
@@ -751,17 +751,3 @@ def dummy_example_depcacahe():
     )
 
     return depc
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m dtool.example_depcache
-        python -m dtool.example_depcache --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dtool/example_depcache2.py
+++ b/wbia/dtool/example_depcache2.py
@@ -225,17 +225,3 @@ def testdata_custom_annot_depc(dummy_dependencies, in_memory=True):
 
     depc.initialize()
     return depc
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m dtool.example_depcache2
-        python -m dtool.example_depcache2 --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dtool/input_helpers.py
+++ b/wbia/dtool/input_helpers.py
@@ -867,17 +867,3 @@ def get_rootmost_inputs(exi_graph, table):
     inputs = TableInput(rmi_list, exi_graph, table, reorder=True)
     # x = inmputs.parent_level()[0].parent_level()[0]  # NOQA
     return inputs
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m dtool.input_helpers
-        python -m dtool.input_helpers --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -3258,17 +3258,3 @@ class SQLTable(ut.NiceRepr):
 
     def __nice__(table):
         return table.name + ', n=' + str(table.number_of_rows())
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m dtool.sql_control
-        python -m dtool.sql_control --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/annotation_configs.py
+++ b/wbia/expt/annotation_configs.py
@@ -924,18 +924,3 @@ include_vars = list(locals().keys())  # this line is after tests
 
 # List of all valid tests
 TEST_NAMES = set(include_vars) - set(exclude_vars)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.expt.annotation_configs
-        python -m wbia.expt.annotation_configs --allexamples
-        python -m wbia.expt.annotation_configs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/cfghelpers.py
+++ b/wbia/expt/cfghelpers.py
@@ -301,18 +301,3 @@ def parse_argv_cfg(argname, default=[''], named_defaults_dict=None, valid_keys=N
     )
     cfg_list = ut.flatten(cfg_combos_list)
     return cfg_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.expt.cfghelpers
-        python -m wbia.expt.cfghelpers --allexamples
-        python -m wbia.expt.cfghelpers --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/experiment_drawing.py
+++ b/wbia/expt/experiment_drawing.py
@@ -1676,18 +1676,3 @@ def draw_match_cases(
         cpq.flush_copy_tasks()
 
     return analysis_fpath_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.expt.experiment_drawing
-        python -m wbia.expt.experiment_drawing --allexamples
-        python -m wbia.expt.experiment_drawing --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/experiment_helpers.py
+++ b/wbia/expt/experiment_helpers.py
@@ -506,18 +506,3 @@ def get_annotcfg_list(
         sys.exit(0)
 
     return acfg_list, expanded_aids_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.expt.experiment_helpers
-        python -m wbia.expt.experiment_helpers --allexamples
-        python -m wbia.expt.experiment_helpers --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/experiment_printres.py
+++ b/wbia/expt/experiment_printres.py
@@ -354,18 +354,3 @@ def rankscore_str(thresh, nLess, total, withlbl=True):
         fmtstr = fmtsf + '/%d = (%.1f%%) (err=' + fmtsf + '/' + str(total) + ')'
         rankscore_str = fmtstr % (nLess, total, percent, (total - nLess))
     return rankscore_str
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.expt.experiment_printres
-        python -m wbia.expt.experiment_printres --allexamples
-        python -m wbia.expt.experiment_printres --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/harness.py
+++ b/wbia/expt/harness.py
@@ -290,17 +290,3 @@ def make_single_testres(
             if ut.SUPER_STRICT:
                 raise
     return testres
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.expt.harness
-        python -m wbia.expt.harness --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/old_storage.py
+++ b/wbia/expt/old_storage.py
@@ -346,17 +346,3 @@ def draw_results(ibs, testres):
 
     if ut.NOT_QUIET:
         print('[DRAW_RESULT] EXIT EXPERIMENT HARNESS')
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.expt.old_storage
-        python -m wbia.expt.old_storage --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/expt/test_result.py
+++ b/wbia/expt/test_result.py
@@ -2694,18 +2694,3 @@ class TestResult(ut.NiceRepr):
         print(', '.join(funcname_list))
         ut.cprint('Available Commandline:', 'blue')
         print('\n'.join(cmdstr_list))
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.expt.test_result
-        python -m wbia.expt.test_result --allexamples
-        python -m wbia.expt.test_result --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/gui/clock_offset_gui.py
+++ b/wbia/gui/clock_offset_gui.py
@@ -323,18 +323,3 @@ def clock_offset_test():
     co = ClockOffsetWidget(ibs, gid_list, hack=True)
     co.show()
     wbia.main_loop(main_locals)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.gui.clock_offset_gui
-        python -m wbia.gui.clock_offset_gui --allexamples
-        python -m wbia.gui.clock_offset_gui --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/gui/guiback.py
+++ b/wbia/gui/guiback.py
@@ -4191,13 +4191,3 @@ def testdata_guiback(defaultdb='testdb2', **kwargs):
         main_locals = wbia.main(defaultdb=defaultdb, **kwargs)
         back = main_locals['back']
     return back
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        xdoctest -m wbia.gui.guiback
-    """
-    import xdoctest
-
-    xdoctest.doctest_module(__file__)

--- a/wbia/gui/guimenus.py
+++ b/wbia/gui/guimenus.py
@@ -612,19 +612,3 @@ def setup_zebra_menu(mainwin, back):
         text='Process ImageSet as Camera Trap Images',
         triggered=back.filter_imageset_as_camera_trap,
     )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.gui.guimenus --test-setup_dummy_menus
-        python -m wbia.gui.guimenus
-        python -m wbia.gui.guimenus --allexamples
-        python -m wbia.gui.guimenus --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/gui/inspect_gui.py
+++ b/wbia/gui/inspect_gui.py
@@ -1199,18 +1199,3 @@ def make_aidpair_tag_context_options(ibs, aid1, aid2):
             )
         )
     return pair_tag_options
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.gui.inspect_gui
-        python -m wbia.gui.inspect_gui --allexamples
-        python -m wbia.gui.inspect_gui --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/gui/newgui.py
+++ b/wbia/gui/newgui.py
@@ -1989,18 +1989,3 @@ def testfunc():
     ibs, back, ibswgt, testdata_main_loop = testdata_guifront()
     view = ibswgt.views[gh.IMAGE_TABLE]
     testdata_main_loop(globals(), locals())
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.gui.newgui
-        python -m wbia.gui.newgui --allexamples
-        python -m wbia.gui.newgui --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/PrefWidget2.py
+++ b/wbia/guitool/PrefWidget2.py
@@ -1097,17 +1097,3 @@ class EditConfigWidget(QtWidgets.QWidget):
     def refresh_layout(self):
         self.config_model.layoutAboutToBeChanged.emit()
         self.config_model.layoutChanged.emit()
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.guitool.PrefWidget2
-        python -m wbia.guitool.PrefWidget2 --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/PreferenceWidget.py
+++ b/wbia/guitool/PreferenceWidget.py
@@ -399,17 +399,3 @@ def test_preference_gui():
     # epw.ui.defaultPrefsBUT.clicked.connect(back.default_config)
     epw.show()
     return old, epw
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.guitool.PreferenceWidget
-        python -m wbia.guitool.PreferenceWidget --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/api_item_model.py
+++ b/wbia/guitool/api_item_model.py
@@ -1142,18 +1142,3 @@ def simple_thumbnail_widget():
     wgt.change_headers(headers)
     # guitool.qtapp_loop(qwin=wgt, ipy=ipy, frequency=loop_freq)
     return wgt
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.api_item_model
-        python -m wbia.guitool.api_item_model --allexamples
-        python -m wbia.guitool.api_item_model --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/api_item_view.py
+++ b/wbia/guitool/api_item_view.py
@@ -434,17 +434,3 @@ def copy_selection_to_clipboard(view):
     clipboard.setText(copy_qstr)
     if VERBOSE:
         print('[guitool] finished copy')
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.guitool.api_item_view
-        python -m wbia.guitool.api_item_view --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/api_item_widget.py
+++ b/wbia/guitool/api_item_widget.py
@@ -579,18 +579,3 @@ class APIItemWidget(WIDGET_BASE):
             # widget.change_headers(widget.api.make_headers())
         if VERBOSE_ITEM_WIDGET:
             print('context request')
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.api_item_widget
-        python -m wbia.guitool.api_item_widget --allexamples
-        python -m wbia.guitool.api_item_widget --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/api_thumb_delegate.py
+++ b/wbia/guitool/api_thumb_delegate.py
@@ -793,18 +793,3 @@ def simple_thumbnail_widget():
     wgt.resize(600, 400)
     # guitool.qtapp_loop(qwin=wgt, ipy=ipy, frequency=loop_freq)
     return wgt
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.api_thumb_delegate
-        python -m wbia.guitool.api_thumb_delegate --allexamples
-        python -m wbia.guitool.api_thumb_delegate --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/api_tree_node.py
+++ b/wbia/guitool/api_tree_node.py
@@ -426,20 +426,3 @@ def build_scope_hack_list(root_node, scope_hack_list=[]):
 
 
 CYTHONIZED = False
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.api_tree_node
-        python -m wbia.guitool.api_tree_node --allexamples
-        python -m wbia.guitool.api_tree_node --allexamples --noface --nosrc
-        python -m wbia.guitool.api_tree_node --allexamples --noface --nosrc --db GZ_ALL
-        python -m wbia.guitool.api_tree_node --allexamples --noface --nosrc --db PZ_Master0
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/api_tree_view.py
+++ b/wbia/guitool/api_tree_view.py
@@ -190,18 +190,3 @@ def testdata_tree_view():
     wgt.menuFile.newAction(triggered=wgt.wgt_embed)
 
     return wgt
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.api_tree_view
-        python -m wbia.guitool.api_tree_view --allexamples
-        python -m wbia.guitool.api_tree_view --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/guitool_components.py
+++ b/wbia/guitool/guitool_components.py
@@ -3032,18 +3032,3 @@ class ComboRadioHybrid(GuitoolWidget):
         for count, rb in enumerate(self.radio_buttons.values()):
             if rb.isChecked():
                 return self.radio_options[count][1]
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.guitool_components
-        python -m wbia.guitool.guitool_components --allexamples
-        python -m wbia.guitool.guitool_components --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/guitool_dialogs.py
+++ b/wbia/guitool/guitool_dialogs.py
@@ -769,18 +769,3 @@ def _getQtImageNameFilter():
     imgNamePat = ' '.join(['*' + ext for ext in util_path.IMG_EXTENSIONS])
     imgNameFilter = 'Images (%s)' % (imgNamePat)
     return imgNameFilter
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.guitool_dialogs
-        python -m wbia.guitool.guitool_dialogs --allexamples
-        python -m wbia.guitool.guitool_dialogs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/guitool_tables.py
+++ b/wbia/guitool/guitool_tables.py
@@ -444,17 +444,3 @@ def make_listtable_widget(
 # widget.show()
 # widget.raise_()
 # sys.exit(app.exec_())
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.guitool.guitool_tables
-        python -m wbia.guitool.guitool_tables --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/mpl_embed.py
+++ b/wbia/guitool/mpl_embed.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # import os
 # import random
 import time
-import utool as ut
 from wbia.guitool.__PYQT__ import QtCore
 from wbia.guitool.__PYQT__ import QtGui as QtWidgets
 from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
@@ -96,17 +95,3 @@ class QtAbstractMplInteraction(BASE):
     @QtCore.pyqtSlot()
     def stop_blocking(self):
         self._running = False
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.guitool.mpl_embed
-        python -m wbia.guitool.mpl_embed --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/mpl_widget.py
+++ b/wbia/guitool/mpl_widget.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
-import utool as ut
 import wbia.guitool as gt
 import matplotlib as mpl
 from wbia.guitool.__PYQT__.QtCore import Qt
@@ -81,17 +80,3 @@ class MatplotlibWidget(gt.GuitoolWidget):
 
         if ih.clicked_inside_axis(event):
             self.click_inside_signal.emit(event, event.inaxes)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.guitool.mpl_widget
-        python -m wbia.guitool.mpl_widget --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/qt_enums.py
+++ b/wbia/guitool/qt_enums.py
@@ -121,17 +121,3 @@ def parse_window_type_and_flags(self):
     print('has = %s' % (ut.repr4(has),))
     print('missing = %s' % (ut.repr4(missing),))
     pass
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.guitool.qt_enums
-        python -m wbia.guitool.qt_enums --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/guitool/tests/test_treenode.py
+++ b/wbia/guitool/tests/test_treenode.py
@@ -83,18 +83,3 @@ def _test_build_internal_structure(_module, lang):
     #    print(api_tree_node.tree_node_string(root_node2, indent=' *  '))
     print('================')
     print('finished %s test' % lang)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.guitool.tests.test_treenode
-        python -m wbia.guitool.tests.test_treenode --allexamples
-        python -m wbia.guitool.tests.test_treenode --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/images.py
+++ b/wbia/images.py
@@ -277,17 +277,3 @@ class ImageSets(IMAGESET_BASE):
     @property
     def annots(self):
         return [self._ibs.annots(aids) for aids in self.aids]
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.images
-        python -m wbia.images --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/init/filter_annots.py
+++ b/wbia/init/filter_annots.py
@@ -2301,18 +2301,3 @@ def verb_context(filtertype, aidcfg, verbose):
                 )
 
     return VerbosityContext
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.init.filter_annots
-        python -m wbia.init.filter_annots --allexamples
-        python -m wbia.init.filter_annots --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/init/main_helpers.py
+++ b/wbia/init/main_helpers.py
@@ -621,18 +621,3 @@ def unmonkeypatch_encounters(ibs):
     ut.inject_func_as_method(
         ibs, ibsfuncs.get_annot_occurrence_text, 'get_annot_occurrence_text', force=True
     )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.init.main_helpers
-        python -m wbia.init.main_helpers --allexamples
-        python -m wbia.init.main_helpers --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/init/sysres.py
+++ b/wbia/init/sysres.py
@@ -886,13 +886,3 @@ def get_global_distinctiveness_modeldir(ensure=True):
     if ensure:
         ut.ensuredir(global_distinctdir)
     return global_distinctdir
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        xdoctest -m wbia.init.sysres
-    """
-    import xdoctest
-
-    xdoctest.doctest_module(__file__)

--- a/wbia/main_module.py
+++ b/wbia/main_module.py
@@ -715,14 +715,3 @@ def main_close(main_locals=None):
 
 # if __name__ == '__main__':
 #    multiprocessing.freeze_support()
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.main_module
-        python -m wbia.main_module --allexamples
-        python -m wbia.main_module --allexamples --noface --nosrc
-    """
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/other/dbinfo.py
+++ b/wbia/other/dbinfo.py
@@ -1211,18 +1211,3 @@ def cache_memory_stats(ibs, cid_list, fnum=None):
         fnum = 0
 
     return fnum + 1
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.other.dbinfo
-        python -m wbia.other.dbinfo --allexamples
-        python -m wbia.other.dbinfo --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/other/detectcore.py
+++ b/wbia/other/detectcore.py
@@ -1259,16 +1259,3 @@ def visualize_bounding_boxes(
         filepath_dict[gid] = write_filepath
 
     return filepath_dict
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.other.detectcore
-        python -m wbia.other.detectcore --allexamples
-        python -m wbia.other.detectcore --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/other/detectexport.py
+++ b/wbia/other/detectexport.py
@@ -608,16 +608,3 @@ def get_cnn_labeler_training_images_pytorch(
     print(ut.repr3(ut.dict_hist(category_list_)))
 
     return name_path
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.other.detectexport
-        python -m wbia.other.detectexport --allexamples
-        python -m wbia.other.detectexport --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/other/detectfuncs.py
+++ b/wbia/other/detectfuncs.py
@@ -4946,16 +4946,3 @@ def detector_parse_gt(ibs, test_gid_list=None, **kwargs):
 #     ibs.localizer_precision_recall_algo_display()
 #     ibs.labeler_precision_recall_algo_display()
 #     ibs.detector_precision_recall_algo_display()
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.other.detectfuncs
-        python -m wbia.other.detectfuncs --allexamples
-        python -m wbia.other.detectfuncs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/other/detectgrave.py
+++ b/wbia/other/detectgrave.py
@@ -2278,16 +2278,3 @@ config_list = [
     # {'label': 'COMBINED 1.0', 'algo': '_COMBINED', 'species_set' : species_set, 'classify': True, 'p': 1.0},
     # {'label': 'COMBINED MUL', 'algo': '_COMBINED', 'species_set' : species_set, 'classify': True},
 ]
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.other.detectgrave
-        python -m wbia.other.detectgrave --allexamples
-        python -m wbia.other.detectgrave --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/other/detecttrain.py
+++ b/wbia/other/detecttrain.py
@@ -930,16 +930,3 @@ def aoi2_train(ibs, species_list=None, train_gid_list=None, purge=True, cache=Fa
     model_state['species_list'] = species_list
     save_model(model_state, model_path)
     return model_path
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.other.detecttrain
-        python -m wbia.other.detecttrain --allexamples
-        python -m wbia.other.detecttrain --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/other/ibsfuncs.py
+++ b/wbia/other/ibsfuncs.py
@@ -9518,16 +9518,3 @@ def export_ggr_folders(ibs, output_path=None):
     census_filepath = join(output_path_census, 'manifest.csv')
     with open(census_filepath, 'w') as census_file:
         census_file.write(census_line_str)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.other.ibsfuncs
-        python -m wbia.other.ibsfuncs --allexamples
-        python -m wbia.other.ibsfuncs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/plottool/color_funcs.py
+++ b/wbia/plottool/color_funcs.py
@@ -747,18 +747,3 @@ def show_all_colormaps():
         else:
             pylab.title(m, rotation=90, fontsize=10)
     # pylab.savefig("colormaps.png", dpi=100, facecolor='gray')
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.color_funcs
-        python -m wbia.plottool.color_funcs --allexamples
-        python -m wbia.plottool.color_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/custom_figure.py
+++ b/wbia/plottool/custom_figure.py
@@ -633,17 +633,3 @@ def set_figtitle(
     window_figtitle = ('fig(%d) ' % fig.number) + figtitle
     window_figtitle = window_figtitle.replace('\n', ' ')
     fig.canvas.set_window_title(window_figtitle)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.plottool.custom_figure
-        python -m wbia.plottool.custom_figure --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/draw_func2.py
+++ b/wbia/plottool/draw_func2.py
@@ -4969,16 +4969,3 @@ def test_save():
     fpath = join(dpath, 'test.png')
     fig.savefig(fpath)
     return fpath
-
-
-if __name__ == '__main__':
-    """
-    commandline:
-        python -m wbia.plottool.draw_func2
-        python -m wbia.plottool.draw_func2 --allexamples
-        python -m wbia.plottool.draw_func2 --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/plottool/draw_sv.py
+++ b/wbia/plottool/draw_sv.py
@@ -263,16 +263,3 @@ def show_sv_simple(
         scale_factor2=sf2,
         **fmatch_kw
     )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.draw_sv
-        python -m wbia.plottool.draw_sv --allexamples
-        python -m wbia.plottool.draw_sv --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/plottool/interact_annotations.py
+++ b/wbia/plottool/interact_annotations.py
@@ -1441,20 +1441,3 @@ def test_interact_annots():
         fnum=0,
     )  # NOQA
     return self
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.interact_annotations --exec-test_interact_annots --show
-    CommandLine:
-        python -m wbia.plottool.interact_annotations
-        python -m wbia.plottool.interact_annotations --allexamples
-        python -m wbia.plottool.interact_annotations --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/interact_impaint.py
+++ b/wbia/plottool/interact_impaint.py
@@ -258,18 +258,3 @@ def draw_demo():
         ax.grid(False)
         ax.set_xticks([])
         ax.set_yticks([])
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.interact_impaint
-        python -m wbia.plottool.interact_impaint --allexamples
-        python -m wbia.plottool.interact_impaint --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/interact_keypoints.py
+++ b/wbia/plottool/interact_keypoints.py
@@ -208,18 +208,3 @@ def ishow_keypoints(chip, kpts, desc, fnum=0, figtitle=None, nodraw=False, **kwa
     ih.connect_callback(fig, 'button_press_event', _on_keypoints_click)
     if not nodraw:
         ph.draw()
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.interact_keypoints
-        python -m wbia.plottool.interact_keypoints --allexamples
-        python -m wbia.plottool.interact_keypoints --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/interact_matches.py
+++ b/wbia/plottool/interact_matches.py
@@ -386,18 +386,3 @@ def show_keypoint_gradient_orientations(
         rchip, kp, sift=vec, mode='vec', fnum=fnum, pnum=pnum
     )
     # pt.set_title('Gradient orientation\n %s, fx=%d' % (get_aidstrs(aid), fx))
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.interact_matches
-        python -m wbia.plottool.interact_matches --allexamples
-        python -m wbia.plottool.interact_matches --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/interact_multi_image.py
+++ b/wbia/plottool/interact_multi_image.py
@@ -358,18 +358,3 @@ class MultiImageInteraction(BASE_CLASS):
     #    self.prev_but = Button(self.prev_ax, 'prev')
     #    self.prev_but.on_clicked(self.display_prev_page)
     #    # Connect the callback whenever the figure is clicked
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.interact_multi_image
-        python -m wbia.plottool.interact_multi_image --allexamples
-        python -m wbia.plottool.interact_multi_image --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/interactions.py
+++ b/wbia/plottool/interactions.py
@@ -318,17 +318,3 @@ class PanEvents(object):
 
         ax.figure.canvas.draw()
         ax.figure.canvas.flush_events()
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.plottool.interactions
-        python -m wbia.plottool.interactions --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/mpl_keypoint.py
+++ b/wbia/plottool/mpl_keypoint.py
@@ -399,18 +399,3 @@ def orientation_actors(kpts, H=None):
         raise
 
     return ori_actors
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.mpl_keypoint
-        python -m wbia.plottool.mpl_keypoint --allexamples
-        python -m wbia.plottool.mpl_keypoint --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/mpl_sift.py
+++ b/wbia/plottool/mpl_sift.py
@@ -317,18 +317,3 @@ def render_sift_on_patch(patch, sift):
         draw_sift_on_patch(patch, sift)
     rendered = render.image
     return rendered
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.mpl_sift
-        python -m wbia.plottool.mpl_sift --allexamples
-        python -m wbia.plottool.mpl_sift --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/nx_helpers.py
+++ b/wbia/plottool/nx_helpers.py
@@ -1935,17 +1935,3 @@ def draw_network2(
 #                                  xytext=xytext[::-1], textcoords=textcoords[::-1],
 #                                  ha='center', va=va, arrowprops=arrowprops)
 #     return xarrow, yarrow
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.plottool.nx_helpers
-        python -m wbia.plottool.nx_helpers --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/plots.py
+++ b/wbia/plottool/plots.py
@@ -2680,18 +2680,3 @@ def wordcloud(text, size=None, fnum=None, pnum=None, ax=None):
     else:
         pt.imshow_null('NO WORDCLOUD DATA', ax=ax)
     ax.axis('off')
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.plots
-        python -m wbia.plottool.plots --allexamples
-        python -m wbia.plottool.plots --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/screeninfo.py
+++ b/wbia/plottool/screeninfo.py
@@ -381,17 +381,3 @@ def get_valid_fig_positions(
 
     valid_positions = [get_position_ix(ix) for ix in range(num_wins)]
     return valid_positions
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.plottool.screeninfo
-        python -m wbia.plottool.screeninfo --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/plottool/viz_featrow.py
+++ b/wbia/plottool/viz_featrow.py
@@ -237,18 +237,3 @@ def draw_feat_row(
         dist_str = '\n'.join(dist_str_list)
         custom_figure.set_xlabel(dist_str)
     return px + nCols
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.plottool.viz_featrow
-        python -m wbia.plottool.viz_featrow --allexamples
-        python -m wbia.plottool.viz_featrow --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/scripts/_neighbor_experiment.py
+++ b/wbia/scripts/_neighbor_experiment.py
@@ -925,24 +925,3 @@ def pyflann_remove_and_save():
         flann4.load_index('test3.flann', clean_vecs)
 
     # assert np.all(idx1 == _idx1), 'rebuild is not determenistic!'
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots._neighbor_experiment
-        python -m wbia.algo.hots._neighbor_experiment --allexamples
-        python -m wbia.algo.hots._neighbor_experiment --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    if ut.get_argflag('--test-augment_nnindexer_experiment'):
-        # See if exec has something to do with memory leaks
-        augment_nnindexer_experiment()
-        ut.show_if_requested()
-        pass
-    else:
-        ut.doctest_funcs()

--- a/wbia/scripts/_thesis_helpers.py
+++ b/wbia/scripts/_thesis_helpers.py
@@ -792,17 +792,3 @@ def ave_str(mean, std, precision=2):
     fmtstr = ''.join([ffmt, '±', ffmt])
     str_ = fmtstr.format(mean, std)
     return str_
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.scripts._thesis_helpers
-        python -m wbia.scripts._thesis_helpers --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/scripts/classify_shark.py
+++ b/wbia/scripts/classify_shark.py
@@ -1421,17 +1421,3 @@ def inspect_results(ds, result_list):
         ibs, config, df_chunks, nCols=len(view_targets)
     )
     inter.start()
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.scripts.classify_shark
-        python -m wbia.scripts.classify_shark --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/scripts/fix_annotation_orientation_issue.py
+++ b/wbia/scripts/fix_annotation_orientation_issue.py
@@ -172,10 +172,3 @@ def fix_annotation_orientation(ibs, min_percentage=0.95):
                         unfixable_gid_list.append(gid)
     print('Un-fixable gid_list = %r' % (unfixable_gid_list,))
     return unfixable_gid_list
-
-
-if __name__ == '__main__':
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/scripts/name_recitifer.py
+++ b/wbia/scripts/name_recitifer.py
@@ -627,17 +627,3 @@ def find_consistent_labeling_old(
             assignment[idx] = '%s%d' % (extra_prefix, num_extra,)
             num_extra += 1
     return assignment
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.scripts.name_recitifer
-        python -m wbia.scripts.name_recitifer --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/scripts/postdoc.py
+++ b/wbia/scripts/postdoc.py
@@ -3128,17 +3128,3 @@ class VerifierExpt(DBInputs):
         dpath = join(str(self.dpath), subdir)
         fpath = join(str(dpath), fname + '_custom.jpg')
         vt.imwrite(fpath, pt.render_figure_to_image(fig, dpi=DPI))
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.scripts.postdoc
-        python -m wbia.scripts.postdoc --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/scripts/specialdraw.py
+++ b/wbia/scripts/specialdraw.py
@@ -2252,17 +2252,3 @@ def system_diagram():
     pt.gca().set_aspect('equal')
 
     ut.show_if_requested()
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.scripts.specialdraw
-        python -m wbia.scripts.specialdraw --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/scripts/thesis.py
+++ b/wbia/scripts/thesis.py
@@ -4378,17 +4378,3 @@ def plot_cmcs2(cdfs, labels, fnum=1, **kwargs):
     pt.adjust_subplots(top=0.8, bottom=0.2, left=0.12, right=0.9)
     fig.set_size_inches([W, H])
     return fig
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.scripts.thesis
-        python -m wbia.scripts.thesis --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/tag_funcs.py
+++ b/wbia/tag_funcs.py
@@ -1058,18 +1058,3 @@ def get_annot_all_tags(ibs, aid_list=None):
         )
     )
     return both_tags_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.tag_funcs
-        python -m wbia.tag_funcs --allexamples
-        python -m wbia.tag_funcs --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/templates/generate_notebook.py
+++ b/wbia/templates/generate_notebook.py
@@ -293,18 +293,3 @@ def make_wbia_cell_list(ibs):
     _format = partial(ut.format_cells, locals_=locals_)
     cell_list = ut.flatten(map(_format, cell_template_list))
     return cell_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.templates.generate_notebook
-        python -m wbia.templates.generate_notebook --allexamples
-        python -m wbia.templates.generate_notebook --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/tests/run_tests.py
+++ b/wbia/tests/run_tests.py
@@ -383,13 +383,3 @@ def convert_tests_from_wbia_to_nose(module_list):
 
     moddir = ut.get_module_dir(tests)
     ut.writeto(join(moddir, 'test_autogen_nose_tests.py'), autogen_test_src)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        xdoctest -m wbia.tests.run_tests
-    """
-    import xdoctest
-
-    xdoctest.doctest_module(__file__)

--- a/wbia/unstable/bayes.py
+++ b/wbia/unstable/bayes.py
@@ -1129,19 +1129,3 @@ def show_model(model, evidence={}, soft_evidence={}, **kwargs):
     # fpath = ('name_model_' + suff + '.png')
     # pt.plt.savefig(fpath)
     # return fpath
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.hots.bayes
-        python -m wbia.algo.hots.bayes --allexamples
-    """
-    if ut.VERBOSE:
-        print('[hs] bayes')
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/clfweb/clfserve.py
+++ b/wbia/unstable/clfweb/clfserve.py
@@ -163,18 +163,3 @@ def run_clf_server():
             )
         )
     tornado.ioloop.IOLoop.instance().start()
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        export PYTHONPATH=$PYTHONPATH:/home/joncrall/code/wbia/wbia/scripts/clfweb
-        python ~/code/wbia/wbia/scripts/clfweb/clfserve.py
-        python ~/code/wbia/wbia/scripts/clfweb/clfserve.py --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/demobayes.py
+++ b/wbia/unstable/demobayes.py
@@ -1036,19 +1036,3 @@ def demo_model_idependencies():
 # xs = [x for x in xs if not x.startswith('( _')]
 # xs = [x for x in xs if not x.endswith('| )')]
 # print('\n'.join(sorted(list(set(xs)))))
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.unstable.demobayes
-        python -m wbia.unstable.demobayes --allexamples
-    """
-    if ut.VERBOSE:
-        print('[hs] demobayes')
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/devcases.py
+++ b/wbia/unstable/devcases.py
@@ -557,18 +557,3 @@ def load_gztest(ibs):
     qaid_list = [testtup.qaid_t for testtup in testtup_list]
     visual_uuids = ibs.get_annot_visual_uuids(qaid_list)
     visual_uuids
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.devcases
-        python -m wbia.algo.hots.devcases --allexamples
-        python -m wbia.algo.hots.devcases --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/distinctiveness_normalizer.py
+++ b/wbia/unstable/distinctiveness_normalizer.py
@@ -686,18 +686,3 @@ def dev_train_distinctiveness(species=None):
         dstcnvs_normer.publish()
     # vsone_
     # inct
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.distinctiveness_normalizer
-        python -m wbia.algo.hots.distinctiveness_normalizer --allexamples
-        python -m wbia.algo.hots.distinctiveness_normalizer --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/gen_cand_expts.py
+++ b/wbia/unstable/gen_cand_expts.py
@@ -541,18 +541,3 @@ def gen_dbranks_tables():
     # sh ExptPrint.sh -t candidacy_baseline --allgt --species=primary --db
     # GZ_ALL --rank-lt-list=1,5,10,100
     pass
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.scripts.gen_cand_expts
-        python -m wbia.scripts.gen_cand_expts --allexamples
-        python -m wbia.scripts.gen_cand_expts --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/iccv.py
+++ b/wbia/unstable/iccv.py
@@ -1501,17 +1501,3 @@ def learn_phi():
     #         rank = cm.get_name_ranks([cm.qnid])[0]
     #         # rank = min(cm.get_annot_ranks(cm.get_groundtruth_daids()))
     #         accumulator[rank] += 1
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.scripts.iccv
-        python -m wbia.scripts.iccv --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/multi_index.py
+++ b/wbia/unstable/multi_index.py
@@ -698,18 +698,3 @@ class MultiNeighborIndex(object):
             qfx2_rankx_,
             qfx2_treex_,
         )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.multi_index
-        python -m wbia.algo.hots.multi_index --allexamples
-        python -m wbia.algo.hots.multi_index --allexamples --noface --nosrc
-
-        utprof.sh wbia/algo/hots/multi_index.py --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    ut.doctest_funcs()

--- a/wbia/unstable/orig_graph_iden.py
+++ b/wbia/unstable/orig_graph_iden.py
@@ -579,17 +579,3 @@ class OrigAnnotInference(object):
             ]
         )
         return inference_dict
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.unstable.orig_graph_iden
-        python -m wbia.unstable.orig_graph_iden --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/pgm_ext.py
+++ b/wbia/unstable/pgm_ext.py
@@ -810,18 +810,3 @@ def markovmodel_test():
     pgm_viz.show_junction_tree(markovmodel)
     # model = markovmodel.to_bayesian_model()
     # customize_model(model)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.hots.pgm_ext
-        python -m wbia.algo.hots.pgm_ext --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    if HAS_PGMPY:
-        ut.doctest_funcs()

--- a/wbia/unstable/pgm_viz.py
+++ b/wbia/unstable/pgm_viz.py
@@ -727,17 +727,3 @@ def show_bayesian_model(model, evidence={}, soft_evidence={}, fnum=None, **kwarg
     # Draw probability hist
     if top_assignments is not None:
         draw_map_histogram(top_assignments, fnum=fnum, pnum=pnum2)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.hots.pgm_viz
-        python -m wbia.algo.hots.pgm_viz --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/precision_recall.py
+++ b/wbia/unstable/precision_recall.py
@@ -204,18 +204,3 @@ def draw_precision_recall_curve_(recall_range_, p_interp_curve, title_pref=None,
     print('Interplated Precision')
     print(ut.repr2(list(zip(recall_range_, p_interp_curve))))
     # fig.show()
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.algo.hots.precision_recall
-        python -m wbia.algo.hots.precision_recall --allexamples
-        python -m wbia.algo.hots.precision_recall --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/scorenorm.py
+++ b/wbia/unstable/scorenorm.py
@@ -1159,18 +1159,3 @@ def get_training_desc_dist(
         fsv_list.append(fsv)
     tp_fsv, tn_fsv = fsv_list
     return tp_fsv, tn_fsv
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.unstable.scorenorm
-        python -m wbia.unstable.scorenorm --allexamples
-        python -m wbia.unstable.scorenorm --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/unstable/testem.py
+++ b/wbia/unstable/testem.py
@@ -679,19 +679,6 @@ def try_em2(prob_names, prob_annots=None):
     return gam
 
 
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.algo.hots.testem
-        python -m wbia.algo.hots.testem --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()
-
 r"""
 
 I've gone over both the pdf and the code and I would like to clarify a few things.

--- a/wbia/viz/interact/interact_annotations2.py
+++ b/wbia/viz/interact/interact_annotations2.py
@@ -188,18 +188,3 @@ class ANNOTATION_Interaction2(object):
                 next_callback=nextcb,
                 prev_callback=prevcb,
             )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.interact.interact_annotations2
-        python -m wbia.viz.interact.interact_annotations2 --allexamples
-        python -m wbia.viz.interact.interact_annotations2 --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/interact/interact_chip.py
+++ b/wbia/viz/interact/interact_chip.py
@@ -602,17 +602,3 @@ def ishow_chip(
 
     if not ischild:
         ih.connect_callback(fig, 'button_press_event', _on_chip_click)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.interact.interact_chip
-        python -m wbia.viz.interact.interact_chip --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/interact/interact_matches.py
+++ b/wbia/viz/interact/interact_matches.py
@@ -407,18 +407,3 @@ class MatchInteraction(interact_matches.MatchInteraction2):
         else:
             return super(MatchInteraction, self).on_click_inside(event, ax)
         self.draw()
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.interact.interact_matches
-        python -m wbia.viz.interact.interact_matches --allexamples
-        python -m wbia.viz.interact.interact_matches --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/interact/interact_name.py
+++ b/wbia/viz/interact/interact_name.py
@@ -770,21 +770,3 @@ class MatchVerificationInteraction(AbstractInteraction):
                 # print(ut.repr2(event.__dict__))
             elif viztype == 'matches':
                 self.cm.ishow_single_annotmatch(self.qreq_, self.aid2, fnum=None, mode=0)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.interact.interact_name --test-ishow_name --show
-        python -m wbia.viz.interact.interact_name --test-testsdata_match_verification --show --db PZ_MTEST --aid1 1 --aid2 30
-
-        python -m wbia.viz.interact.interact_name
-        python -m wbia.viz.interact.interact_name --allexamples
-        python -m wbia.viz.interact.interact_name --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/interact/interact_qres.py
+++ b/wbia/viz/interact/interact_qres.py
@@ -167,18 +167,3 @@ class InteractQres(BASE_CLASS):
                     print('[viz] result clicked')
                     self.show_matches_to_aid(aid2)
         self.draw()
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.interact.interact_qres
-        python -m wbia.viz.interact.interact_qres --allexamples
-        python -m wbia.viz.interact.interact_qres --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/interact/interact_query_decision.py
+++ b/wbia/viz/interact/interact_query_decision.py
@@ -448,18 +448,3 @@ class QueryVerificationInteraction(AbstractInteraction):
                     # self.show_page()
                     # ibs.print_annotation_table()
                 print(ut.repr2(event.__dict__))
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.interact.interact_query_decision
-        python -m wbia.viz.interact.interact_query_decision --allexamples
-        python -m wbia.viz.interact.interact_query_decision --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_chip.py
+++ b/wbia/viz/viz_chip.py
@@ -279,18 +279,3 @@ def show_chip(
             cb = pt.colorbar(weights, kwargs['color'])
             cb.set_label(weight_label)
     return fig, ax
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_chip
-        python -m wbia.viz.viz_chip --allexamples
-        python -m wbia.viz.viz_chip --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_graph.py
+++ b/wbia/viz/viz_graph.py
@@ -935,18 +935,3 @@ def tryout_with_qt():
     insp.show()
 
     app.exec_()
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_graph
-        python -m wbia.viz.viz_graph --allexamples
-        python -m wbia.viz.viz_graph --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_graph2.py
+++ b/wbia/viz/viz_graph2.py
@@ -2629,20 +2629,3 @@ def make_qt_graph_interface(
         win.expand_image_and_names()
 
     return win
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.viz.viz_graph2
-        python -m wbia.viz.viz_graph2 --allexamples
-        wbia make_qt_graph_interface --show --aids=1,2,3,4,5,6,7,8,9 --graph
-
-        python -m wbia.viz.viz_graph2 make_qt_graph_interface --show --aids=1,2,3,4,5,6,7 --graph --match=1,4 --nomatch=3,1,5,7
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_helpers.py
+++ b/wbia/viz/viz_helpers.py
@@ -425,18 +425,3 @@ def kp_info(kp):
 
 
 # ----
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_helpers
-        python -m wbia.viz.viz_helpers --allexamples
-        python -m wbia.viz.viz_helpers --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_hough.py
+++ b/wbia/viz/viz_hough.py
@@ -78,17 +78,3 @@ def show_probability_chip(
         img = vt.blend_images_multiply(chip, vt.resize_mask(img, chip))
     fig, ax = viz_image2.show_image(img, title=title, fnum=fnum, **kwargs)
     return fig, ax
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.viz.viz_hough
-        python -m wbia.viz.viz_hough --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_image.py
+++ b/wbia/viz/viz_image.py
@@ -246,18 +246,3 @@ def show_image(
     ph.set_plotdat(ax, 'viztype', 'image')
     ph.set_plotdat(ax, 'gid', gid)
     return fig, ax
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_image
-        python -m wbia.viz.viz_image --allexamples
-        python -m wbia.viz.viz_image --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_matches.py
+++ b/wbia/viz/viz_matches.py
@@ -826,20 +826,3 @@ def show_multichip_match(
             pt.colorbar(flat_fs, flat_colors)
     bbox_list = [(x, y, w, h) for (x, y), (w, h) in zip(offset_list, wh_list)]
     return offset_list, sf_list, bbox_list
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_matches --test-show_matches --show
-
-        python -m wbia.viz.viz_matches
-        python -m wbia.viz.viz_matches --allexamples
-        python -m wbia.viz.viz_matches --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_name.py
+++ b/wbia/viz/viz_name.py
@@ -402,18 +402,3 @@ def show_name(
     # gs2.tight_layout(fig)
     # gs2.update(top=df2.TOP_SUBPLOT_ADJUST)
     # df2.set_figtitle(title, subtitle)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_name
-        python -m wbia.viz.viz_name --allexamples
-        python -m wbia.viz.viz_name --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_nearest_descriptors.py
+++ b/wbia/viz/viz_nearest_descriptors.py
@@ -359,18 +359,3 @@ def show_nearest_descriptors(ibs, qaid, qfx, fnum=None, stride=5, qreq_=None, **
         print('[viz] Error in show nearest descriptors')
         print(ex)
         raise
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_nearest_descriptors
-        python -m wbia.viz.viz_nearest_descriptors --allexamples
-        python -m wbia.viz.viz_nearest_descriptors --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_other.py
+++ b/wbia/viz/viz_other.py
@@ -63,17 +63,3 @@ def image_montage(ibs, gids, config=None):
     dsize = (int(height * ut.PHI), height)
     dst = vt.montage(img_list, dsize)
     pt.imshow(dst)
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.viz.viz_other
-        python -m wbia.viz.viz_other --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_qres.py
+++ b/wbia/viz/viz_qres.py
@@ -510,18 +510,3 @@ def show_qres(ibs, cm, qreq_=None, **kwargs):
 
     # Result Interaction
     return fig
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_qres
-        python -m wbia.viz.viz_qres --allexamples
-        python -m wbia.viz.viz_qres --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/viz/viz_sver.py
+++ b/wbia/viz/viz_sver.py
@@ -88,12 +88,3 @@ def show_sver(
     draw_sv.show_sv(
         chip1, chip2, kpts1, kpts2, fm, homog_tup=homog_tup, aff_tup=aff_tup, **kwargs
     )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.viz.viz_sver --allexamples
-        python -m wbia.viz.viz_sver --allexamples --show
-    """
-    ut.doctest_funcs()

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -502,18 +502,3 @@ def api_test_datasets_id(ibs, dataset, *args, **kwargs):
     }
 
     return response
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/apis_detect.py
+++ b/wbia/web/apis_detect.py
@@ -1191,18 +1191,3 @@ def detect_ws_injury(ibs, gid_list):
 
     labels = labelShark.classifyShark(ibs, gid_list)
     return labels
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -886,17 +886,3 @@ def start_flukebook_sync(ibs, **kwargs):
     """
     jobid = ibs.job_manager.jobiface.queue_job('flukebook_sync')
     return jobid
-
-
-if __name__ == '__main__':
-    r"""
-    CommandLine:
-        python -m wbia.web.apis_engine
-        python -m wbia.web.apis_engine --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/apis_json.py
+++ b/wbia/web/apis_json.py
@@ -2199,18 +2199,3 @@ def delete_name_json(ibs, name_uuid_list):
     nid_list = ibs.get_name_rowids_from_uuid(name_uuid_list)
     ibs.delete_names(nid_list)
     return True
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/apis_microsoft.py
+++ b/wbia/web/apis_microsoft.py
@@ -1516,18 +1516,3 @@ def microsoft_get_test_data(ibs, dataset):
         response[key] = [_annotation(ibs, aid) for aid in aid_list]
 
     return response
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -1997,18 +1997,3 @@ def query_graph_v2_on_request_review(future):
             graph_client.update(None)
             callback_type = 'finished'
         query_graph_v2_callback(graph_client, callback_type)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/apis_sync.py
+++ b/wbia/web/apis_sync.py
@@ -617,18 +617,3 @@ def detect_remote_sync_images(ibs, gid_list=None, only_sync_missing_images=True)
     if len(part_uuid_list) > 0:
         ibs._detect_remote_push_part_metadata(part_uuid_list)
     print('...synched')
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/app.py
+++ b/wbia/web/app.py
@@ -302,18 +302,3 @@ def start_web_annot_groupreview(ibs, aid_list):
     aid_strs = ','.join(list(map(str, aid_list)))
     url_suffix = '/group_review/?aid_list=%s' % (aid_strs)
     wbia.web.app.start_from_wbia(ibs, url_suffix=url_suffix, browser=True)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/graph_server.py
+++ b/wbia/web/graph_server.py
@@ -573,17 +573,3 @@ class GraphClient(object):
         priority, data_dict = client.review_dict[edge]
         print('SAMPLED edge = {!r}'.format(edge))
         return edge, priority, data_dict
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.graph_server
-        python -m wbia.web.graph_server --allexamples
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/job_engine.py
+++ b/wbia/web/job_engine.py
@@ -1957,18 +1957,3 @@ def _init_signals():
     import signal
 
     signal.signal(signal.SIGINT, _on_ctrl_c)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.job_engine
-        python -m wbia.web.job_engine --allexamples
-        python -m wbia.web.job_engine --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/routes.py
+++ b/wbia/web/routes.py
@@ -5686,18 +5686,3 @@ def error404(exception=None):
     return appf.template(
         None, '404', exception_str=exception_str, traceback_str=traceback_str
     )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/routes_ajax.py
+++ b/wbia/web/routes_ajax.py
@@ -115,18 +115,3 @@ def part_src(part_rowid, **kwargs):
     image = ibs.get_part_chips(part_rowid, config2_=kwargs)
     image_src = appf.embed_image_html(image, target_height=300)
     return image_src
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/routes_csv.py
+++ b/wbia/web/routes_csv.py
@@ -732,18 +732,3 @@ def get_aid_list_csv(**kwargs):
     return_str = '\n'.join(map(str, aid_list))
     return_str = 'AID\n' + return_str
     return appf.send_csv_file(return_str, filename)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/routes_demo.py
+++ b/wbia/web/routes_demo.py
@@ -18,18 +18,3 @@ def demo(*args, **kwargs):
 
     embedded = dict(globals(), **locals())
     return appf.template(None, 'demo', **embedded)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/routes_experiments.py
+++ b/wbia/web/routes_experiments.py
@@ -589,18 +589,3 @@ def experiments_voting(**kwargs):
 
     embed = dict(globals(), **locals())
     return appf.template('experiments', 'voting', **embed)
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/routes_submit.py
+++ b/wbia/web/routes_submit.py
@@ -1779,18 +1779,3 @@ def submit_contour(**kwargs):
         return redirect(
             url_for('turk_contour', imgsetid=imgsetid, previous=part_rowid, **config)
         )
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.app
-        python -m wbia.web.app --allexamples
-        python -m wbia.web.app --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()

--- a/wbia/web/test_api.py
+++ b/wbia/web/test_api.py
@@ -116,18 +116,3 @@ def run_test_api():
     status_code, text, json = response
     web_instance.terminate()
     return response
-
-
-if __name__ == '__main__':
-    """
-    CommandLine:
-        python -m wbia.web.test_api
-        python -m wbia.web.test_api --allexamples
-        python -m wbia.web.test_api --allexamples --noface --nosrc
-    """
-    import multiprocessing
-
-    multiprocessing.freeze_support()  # for win32
-    import utool as ut  # NOQA
-
-    ut.doctest_funcs()


### PR DESCRIPTION
The testing path is to invoke `pytest` to run tests. If a script is
actually intended to be run as a script, it will have a `__main__`
check. Otherwise, we standardize on test invocation being done through
`pytest`.

For example, the equivalent invocation for `wbia/algo/graph/demo.py` will
be `pytest wbia/algo/graph/demo.py`.

This change removes the `__main__` check where xdoctest is the invocation.

This is in an effort to remove boilerplate redundancy code from the
files. This also helps to suggest which files are really script-like
files.

In the same vein of things, I've also modified `wbia.__main__` to no longer contain code that will execute tests.

---

I used the following script to for a first pass then used `git add -p` to make sure I wasn't removing anything for script-like modules.

<details>
<summary>__main__ check removal script</summary>

```python
#!/usr/bin/env python3
import re
from pathlib import Path


from contextlib import contextmanager
import io
import os


# https://www.zopatista.com/python/2013/11/26/inplace-file-rewriting/
@contextmanager
def inplace(filename, mode='r', buffering=-1, encoding=None, errors=None,
            newline=None, backup_extension=None):
    """Allow for a file to be replaced with new content.

    yields a tuple of (readable, writable) file objects, where writable
    replaces readable.

    If an exception occurs, the old file is restored, removing the
    written data.

    mode should *not* use 'w', 'a' or '+'; only read-only-modes are supported.

    """

    # move existing file to backup, create new file with same permissions
    # borrowed extensively from the fileinput module
    if set(mode).intersection('wa+'):
        raise ValueError('Only read-only file modes can be used')

    backupfilename = filename + (backup_extension or os.extsep + 'bak')
    try:
        os.unlink(backupfilename)
    except os.error:
        pass
    os.rename(filename, backupfilename)
    readable = io.open(backupfilename, mode, buffering=buffering,
                       encoding=encoding, errors=errors, newline=newline)
    try:
        perm = os.fstat(readable.fileno()).st_mode
    except OSError:
        writable = open(filename, 'w' + mode.replace('r', ''),
                        buffering=buffering, encoding=encoding, errors=errors,
                        newline=newline)
    else:
        os_mode = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
        if hasattr(os, 'O_BINARY'):
            os_mode |= os.O_BINARY
        fd = os.open(filename, os_mode, perm)
        writable = io.open(fd, "w" + mode.replace('r', ''), buffering=buffering,
                           encoding=encoding, errors=errors, newline=newline)
        try:
            if hasattr(os, 'chmod'):
                os.chmod(filename, perm)
        except OSError:
            pass
    try:
        yield readable, writable
    except Exception:
        # move backup back
        try:
            os.unlink(filename)
        except os.error:
            pass
        os.rename(backupfilename, filename)
        raise
    finally:
        readable.close()
        writable.close()
        try:
            os.unlink(backupfilename)
        except os.error:
            pass


target = re.compile(r"^if __name__ == '__main__':", re.MULTILINE)


root = Path('wbia')


def main():
    for i, f in enumerate(root.glob('**/*.py')):
        print(f"--- {f} " + ("-"* 20))
        with inplace(str(f), 'r') as (i, o):
            rtxt = i.read()
            m = target.search(rtxt)
            if m:
                print(f'rewrote {f}')
                trunc_pos = m.span()[0]
                otxt = rtxt[:trunc_pos]
                print(f'dropped: {rtxt[trunc_pos:]}')
            else:
                print(f'skipping {f}')
                otxt = rtxt
            o.write(otxt)
            
    return 0

if __name__ == '__main__':
    main()

```  
</details>
