### PR TITLE
Set pyqt5 version to >=5.11.2,<5.12 in requirements/runtime.txt

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -25,7 +25,7 @@ pygments>=2.1.3
 pynmea2>=1.5.3
 pyparsing>=2.1.5
 
-pyqt5>= 5.11.2
+pyqt5>=5.11.2,<5.12
 pyzmq>=14.7.0
 requests>=2.5.0
 scikit-image>=0.12.3


### PR DESCRIPTION
Newer versions of `pyqt5` (current version is `5.15.0`) causes "core
dump" during tests:

```
...
wbia/algo/graph/demo.py s.Fatal Python error: Aborted

Current thread 0x00007f8d0c9de740 (most recent call first):
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/backends/backend_qt5.py", line 122 in _create_qApp
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/backends/backend_qt5.py", line 226 in __init__
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/backends/backend_qt5agg.py", line 21 in __init__
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/backend_bases.py", line 3224 in new_figure_manager_given_figure
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/backend_bases.py", line 3218 in new_figure_manager
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/pyplot.py", line 525 in figure
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/pyplot.py", line 578 in gcf
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/pyplot.py", line 935 in gca
  File "/virtualenv/env3/lib/python3.6/site-packages/matplotlib/pyplot.py", line 2656 in hist
  File "/wbia/wildbook-ia/wbia/algo/graph/demo.py", line 761 in show_score_probs
  File "<doctest:/wbia/wildbook-ia/wbia/algo/graph/demo.py::DummyVerif.show_score_probs:0>", line 6 in <module>
  File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 556 in run
  File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/plugin.py", line 172 in runtest
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/runner.py", line 135 in pytest_runtest_call
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/runner.py", line 217 in <lambda>
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/runner.py", line 244 in from_call
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/runner.py", line 217 in call_runtest_hook
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/runner.py", line 186 in call_and_report
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/runner.py", line 100 in runtestprotocol
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/runner.py", line 85 in pytest_runtest_protocol
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/main.py", line 272 in pytest_runtestloop
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/main.py", line 247 in _main
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/main.py", line 191 in wrap_session
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/main.py", line 240 in pytest_cmdline_main
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/callers.py", line 187 in _multicall
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 87 in <lambda>
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/manager.py", line 93 in _hookexec
  File "/virtualenv/env3/lib/python3.6/site-packages/pluggy/hooks.py", line 286 in __call__
  File "/virtualenv/env3/lib/python3.6/site-packages/_pytest/config/__init__.py", line 125 in main
  File "/virtualenv/env3/bin/pytest", line 8 in <module>
Aborted (core dumped)
```