### PR TITLE
Move pytest's conftest module up to increase scope

### DIFF
--- a/wbia/conftest.py
+++ b/wbia/conftest.py
@@ -13,7 +13,7 @@ from wbia.init.sysres import (
     get_workdir,
     set_default_dbdir,
 )
-from .reset_testdbs import (
+from wbia.tests.reset_testdbs import (
     TEST_DBNAMES_MAP,
     delete_dbdir,
     ensure_smaller_testingdbs,


### PR DESCRIPTION
The pytest `conftest.py` file is where pytest scoped fixtures are
registered.

The scope of `conftest.py` is the package it resides within.
Placing this in a `tests` directory on most projects, as the
convention goes, would work, but not for the wildbook-ia tests.
This is due to the tests not being scoped to a specific portion of the
code. Because of this we need to move our testing fixtures code into
the main code.

This fixes the `set_up_db` fixture to run prior to running the xdoctests.