### PR TITLE
Skip xdoctest unless wbia_cnn is available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from os.path import exists
 from collections import OrderedDict
 
-# from setuptools import find_packages
+from setuptools import find_packages
 from skbuild import setup
 
 
@@ -243,8 +243,7 @@ KWARGS = OrderedDict(
         'tag_regex': '^(?P<prefix>v)?(?P<version>[^\\+]+)(?P<suffix>.*)?$',
         'local_scheme': 'dirty-tag',
     },
-    # packages=find_packages(),
-    packages=['wbia'],
+    packages=find_packages(),
     package_dir={'wbia': 'wbia'},
     python_requires='>=3.5, <4',
     include_package_data=False,

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ KWARGS = OrderedDict(
     },
     packages=find_packages(),
     package_dir={'wbia': 'wbia'},
-    python_requires='>=3.5, <4',
+    python_requires='>=3.6, <4',
     include_package_data=False,
     # List of classifiers available at:
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/wbia/core_annots.py
+++ b/wbia/core_annots.py
@@ -890,6 +890,7 @@ def postprocess_mask(mask, thresh=20, kernel_size=20):
         rowid_kw = dict(config=config)
 
     Doctest:
+        >>> # xdoctest: +REQUIRES(module:wbia_cnn)
         >>> from wbia.core_annots import *  # NOQA
         >>> import wbia.plottool as pt
         >>> ibs, depc, aid_list = testdata_core()
@@ -1292,6 +1293,7 @@ def compute_fgweights(depc, fid_list, pcid_list, config=None):
         python -m wbia.core_annots compute_fgweights
 
     Doctest:
+        >>> # xdoctest: +REQUIRES(module:wbia_cnn)
         >>> from wbia.core_annots import *  # NOQA
         >>> ibs, depc, aid_list = testdata_core()
         >>> full_config = {}
@@ -1345,6 +1347,7 @@ def gen_featweight_worker(kpts, probchip, chipsize):
         python -m wbia.core_annots --test-gen_featweight_worker --show --db PZ_MTEST --qaid_list=1,2,3,4,5,6,7,8,9
 
     Doctest:
+        >>> # xdoctest: +REQUIRES(module:wbia_cnn)
         >>> from wbia.core_annots import *  # NOQA
         >>> #test_featweight_worker()
         >>> ibs, depc, aid_list = testdata_core()


### PR DESCRIPTION
This change corrects the following
AttributeError. `generate_species_background_mask` is a plugin method
defined by the wbia_cnn plugin.

AttributeError: 'IBEISController' object has no attribute 'generate_species_background_mask'