### PR TITLE
Uncomment and rename main to smoke_test

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,7 +32,7 @@ jobs:
           # Using manylinux2014 because running the test command requires
           # pyqt5 which only has wheels for manylinux2014
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
-          CIBW_TEST_COMMAND: python -c "import wbia; from wbia.__main__ import main; main()"
+          CIBW_TEST_COMMAND: python -c "import wbia; from wbia.__main__ import smoke_test; smoke_test()"
         run: |
           python -m pip install cibuildwheel==1.4.2
           python -m cibuildwheel --output-dir wheelhouse

--- a/wbia/__main__.py
+++ b/wbia/__main__.py
@@ -40,13 +40,15 @@ def dependencies_for_myprogram():
     importlib.import_module('mpl_toolkits').__path__
 
 
-# def main():  # nocover
-#     import wbia
+# FIXME (27-Jul-12020) This is currently used by CI to verify installation.
+#       Either make this the main function or move to location that makes sense.
+def smoke_test():  # nocover
+    import wbia
 
-#     print('Looks like the imports worked')
-#     print('wbia = {!r}'.format(wbia))
-#     print('wbia.__file__ = {!r}'.format(wbia.__file__))
-#     print('wbia.__version__ = {!r}'.format(wbia.__version__))
+    print('Looks like the imports worked')
+    print('wbia = {!r}'.format(wbia))
+    print('wbia.__file__ = {!r}'.format(wbia.__file__))
+    print('wbia.__version__ = {!r}'.format(wbia.__version__))
 
 
 def run_wbia():


### PR DESCRIPTION
This function isn't actually the main function. I commented it out in
a previous commit, because it's not used within the code. Turns out we
are using it in CI though, so I'm bringing it back but with a more apt
name.

And with this, the CI is finally passing ✅. It's not running the tests, but it's a start. 😹 