### PR TITLE
Notify us on slack of nightly build failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * *' # Every day at midnight
   pull_request:
     paths:
-      - '.github/workflows/nightly-container-build.yml'
+      - '.github/workflows/nightly.yml'
       - 'devops/**'
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,3 +31,15 @@ jobs:
       - name: Push to Docker Hub
         if: github.event_name == 'schedule'
         run: bash devops/publish.sh -t nightly
+
+      # Notify status in Slack
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: ia-development
+          SLACK_COLOR: '#FF0000'
+          SLACK_ICON: https://avatars.slack-edge.com/2020-03-02/965719891842_db87aa21ccb61076f236_44.png
+          SLACK_MESSAGE: 'nightly build failed :sob:'
+          SLACK_USERNAME: "Nightly"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,9 @@ name: Nightly
 on:
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
+  push:
+    paths:
+      - '.github/workflows/nightly.yml'
   pull_request:
     paths:
       - '.github/workflows/nightly.yml'


### PR DESCRIPTION
This will notify us when the nightly build fails. Right now it's not
giving us any feedback when it's failed. It's best to catch the
failures early so that don't creep up on us when we need things to
"just work."

It's only setup to notify us when the build fails. Otherwise, we can expect that the nightly build passes.

Note, the nightly build is currently failing and will be fixed in another PR.