### PR TITLE
Disable macos-latest on github testing workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest] # Disable "macos-latest" for now
         # For speed, we choose one version and that should be the lowest common denominator
         python-version: [3.6]
 


### PR DESCRIPTION
There are some failures that we're not sure we want to fix at the
moment:

```
...
DOCTEST TRACEBACK
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.6.11/x64/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 556, in run
    exec(code, test_globals)
  File "<doctest:/Users/runner/work/wildbook-ia/wildbook-ia/wbia/web/apis.py::annot_src_api:0>", line rel: 4, abs: 129, in <module>
    >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
  File "/Users/runner/work/wildbook-ia/wildbook-ia/wbia/main_module.py", line 516, in opendb_bg_web
    wait_until_started()
  File "/Users/runner/work/wildbook-ia/wildbook-ia/wbia/main_module.py", line 507, in wait_until_started
    for count in ut.delayed_retry_gen([1], timeout=15):
  File "/Users/runner/hostedtoolcache/Python/3.6.11/x64/lib/python3.6/site-packages/utool/util_dev.py", line 1308, in delayed_retry_gen
Exception: Retry loop timed out
DOCTEST REPRODUCTION
CommandLine:
    pytest /Users/runner/work/wildbook-ia/wildbook-ia/wbia/web/apis.py::annot_src_api:0
...
wbia/plottool/__MPL_INIT__.py:177
  /Users/runner/work/wildbook-ia/wildbook-ia/wbia/plottool/__MPL_INIT__.py:177: MatplotlibDeprecationWarning:
  The keymap.all_axes rcparam was deprecated in Matplotlib 3.3 and will be removed two minor releases later.
Fatal Python error: Segmentation fault
...
=========================== short test summary info ============================
FAILED wbia/web/apis.py::annot_src_api:0
FAILED wbia/web/apis.py::background_src_api:0
FAILED wbia/web/job_engine.py::get_job_metadata:0
===== 3 failed, 629 passed, 641 skipped, 128 warnings in 857.24s (0:14:17) =====
```

So we will disable testing on macos-latest for now.

See https://github.com/WildbookOrg/wildbook-ia/runs/932837233?check_suite_focus=true