### PR TITLE
Add require flags as options to pytest in conftest.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,6 +238,11 @@ Our code uses Google-style documentation tests (doctests) that uses pytest and x
 
     pytest
 
+To run doctests with `+REQUIRES(--web)` do:
+
+.. code:: bash
+
+    pytest --web
 
 .. |Build| image:: https://img.shields.io/github/workflow/status/WildbookOrg/wildbook-ia/Build%20and%20upload%20to%20PyPI/master
     :target: https://github.com/WildbookOrg/wildbook-ia/actions?query=branch%3Amaster+workflow%3A%22Build+and+upload+to+PyPI%22

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+def pytest_addoption(parser):
+    # This needs to be in the project root not in wbia/conftest.py otherwise
+    # e.g. "pytest --gui" doesn't work.
+    parser.addoption('--fixme', action='store_true')
+    parser.addoption('--gui', action='store_true')
+    parser.addoption('--show', action='store_true')
+    parser.addoption('--tomcat', action='store_true')
+    parser.addoption('--web', action='store_true')
+    parser.addoption('--weird', action='store_true')


### PR DESCRIPTION
All the doctests that have `+REQUIRES(--flag)` need to be added as flags
to pytest in order to be able to run:

```
pytest --flag
```

I found the flags used in the tests by doing:

```
git grep '+REQUIRES(--' '*.py' | sed 's/.*+REQUIRES(--\([^)]*\))/\1/' | sort | uniq
```

The options need to be added to the `conftest.py` in the project root
otherwise `pytest --flag` doesn't work.