### PR TITLE
SQL Controller instantiation from URI

### DIFF
--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -25,7 +25,9 @@ from wbia.dtool.dump import dumps
 print, rrr, profile = ut.inject2(__name__)
 
 
-METADATA_TABLE = 'metadata'
+# FIXME (31-Jul-12020) Duplicate definition of wbia.constants.METADATA_TABLE
+#       Use this definition as the authority because it's within the context of its use.
+METADATA_TABLE_NAME = 'metadata'
 
 READ_ONLY = ut.get_argflag(('--readonly-mode', '--read-only', '--readonly'))
 VERBOSE_SQL = ut.get_argflag(('--print-sql', '--verbose-sql', '--verb-sql', '--verbsql'))
@@ -536,13 +538,13 @@ class SQLDatabaseController(object):
         correctly.
         """
         try:
-            orig_table_kw = self.get_table_autogen_dict(METADATA_TABLE)
+            orig_table_kw = self.get_table_autogen_dict(METADATA_TABLE_NAME)
         except (lite.OperationalError, NameError):
             orig_table_kw = None
 
         meta_table_kw = ut.odict(
             [
-                ('tablename', METADATA_TABLE),
+                ('tablename', METADATA_TABLE_NAME),
                 (
                     'coldef_list',
                     [
@@ -564,7 +566,7 @@ class SQLDatabaseController(object):
         if meta_table_kw != orig_table_kw:
             # Don't execute a write operation if we don't have to
             self.add_table(**meta_table_kw)
-        # METADATA_TABLE,
+        # METADATA_TABLE_NAME,
         #    superkeys=[('metadata_key',)],
         # IMPORTANT: Yes, we want this line to be tabbed over for the
         # schema auto-generation
@@ -586,7 +588,7 @@ class SQLDatabaseController(object):
                 return [None] * len(x)
 
             self.add_cleanly(
-                METADATA_TABLE, colnames, params_iter, get_rowid_from_superkey
+                METADATA_TABLE_NAME, colnames, params_iter, get_rowid_from_superkey
             )
         return version
 
@@ -630,7 +632,7 @@ class SQLDatabaseController(object):
                 return [None] * len(x)
 
             self.add_cleanly(
-                METADATA_TABLE, colnames, params_iter, get_rowid_from_superkey
+                METADATA_TABLE_NAME, colnames, params_iter, get_rowid_from_superkey
             )
         db_init_uuid = uuid.UUID(db_init_uuid_str)
         return db_init_uuid
@@ -1516,9 +1518,9 @@ class SQLDatabaseController(object):
             >>> result = ('metadata_items = %s' % (ut.repr2(sorted(metadata_items)),))
             >>> print(result)
         """
-        metadata_rowids = self.get_all_rowids(METADATA_TABLE)
+        metadata_rowids = self.get_all_rowids(METADATA_TABLE_NAME)
         metadata_items = self.get(
-            METADATA_TABLE, ('metadata_key', 'metadata_value'), metadata_rowids
+            METADATA_TABLE_NAME, ('metadata_key', 'metadata_value'), metadata_rowids
         )
         return metadata_items
 
@@ -1526,7 +1528,10 @@ class SQLDatabaseController(object):
         """
         key must be given as a repr-ed string
         """
-        fmtkw = {'tablename': METADATA_TABLE, 'columns': 'metadata_key, metadata_value'}
+        fmtkw = {
+            'tablename': METADATA_TABLE_NAME,
+            'columns': 'metadata_key, metadata_value',
+        }
         op_fmtstr = 'INSERT OR REPLACE INTO {tablename} ({columns}) VALUES (?, ?)'
         operation = op_fmtstr.format(**fmtkw)
         params = [key, val]
@@ -1540,7 +1545,7 @@ class SQLDatabaseController(object):
         where_clause = 'metadata_key=?'
         colnames = ('metadata_value',)
         params_iter = [(key,)]
-        vals = self.get_where(METADATA_TABLE, colnames, params_iter, where_clause)
+        vals = self.get_where(METADATA_TABLE_NAME, colnames, params_iter, where_clause)
         assert len(vals) == 1, 'duplicate keys in metadata table'
         val = vals[0]
         if val is None:
@@ -1969,7 +1974,9 @@ class SQLDatabaseController(object):
         val_iter = [(key,) for key in key_new_list]
         colnames = ('metadata_key',)
         # print('Setting metadata_key from %s to %s' % (ut.repr2(id_iter), ut.repr2(val_iter)))
-        self.set(METADATA_TABLE, colnames, val_iter, id_iter, id_colname='metadata_key')
+        self.set(
+            METADATA_TABLE_NAME, colnames, val_iter, id_iter, id_colname='metadata_key'
+        )
 
     def drop_table(self, tablename):
         if VERBOSE_SQL:
@@ -1986,7 +1993,7 @@ class SQLDatabaseController(object):
 
         # Delete table's metadata
         key_list = [tablename + '_' + suffix for suffix in self.table_metadata_keys]
-        self.delete(METADATA_TABLE, key_list, id_colname='metadata_key')
+        self.delete(METADATA_TABLE_NAME, key_list, id_colname='metadata_key')
 
     def drop_all_tables(self):
         """
@@ -2358,7 +2365,7 @@ class SQLDatabaseController(object):
         # where_clause = 'metadata_key=?'
         # colnames = ('metadata_value',)
         # data = [(tablename + '_docstr',)]
-        # docstr = self.get_where(const.METADATA_TABLE, colnames, data, where_clause)[0]
+        # docstr = self.get_where(const.METADATA_TABLE_NAME, colnames, data, where_clause)[0]
         return docstr
 
     def get_columns(self, tablename):
@@ -3179,7 +3186,7 @@ class SQLDatabaseController(object):
         where_clause = 'metadata_key=?'
         # list of relationships for each image
         metadata_rowid_list = self.get_where(
-            METADATA_TABLE,
+            METADATA_TABLE_NAME,
             ('metadata_rowid',),
             params_iter,
             where_clause,
@@ -3190,7 +3197,7 @@ class SQLDatabaseController(object):
         ), 'duplicate database_version keys in database'
         id_iter = ((metadata_rowid,) for metadata_rowid in metadata_rowid_list)
         val_list = ((_,) for _ in [version])
-        self.set(METADATA_TABLE, ('metadata_value',), val_list, id_iter)
+        self.set(METADATA_TABLE_NAME, ('metadata_value',), val_list, id_iter)
 
     def get_sql_version(self):
         """ Conveinience """

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -455,12 +455,6 @@ class SQLDatabaseController(object):
             self.squeeze()
             self._copy_to_memory()
 
-        self.USE_FOREIGN_HACK = False
-        if self.USE_FOREIGN_HACK:
-            self.cur.execute('PRAGMA foreign_keys = ON')
-            # self.cur.execute("PRAGMA foreign_keys;")
-            # print(self.cur.fetchall())
-
         # Optimize the database (if anything is set)
         if is_new:
             self.optimize()
@@ -1672,34 +1666,8 @@ class SQLDatabaseController(object):
         foreign_body = []
         # False
         for (name, type_) in coldef_list:
-            if self.USE_FOREIGN_HACK and name.endswith('_rowid'):
-                # HACK THAT ONLY WORKS WITH IBEIS STRUCTURE
-                foreign_table = name[: -len('_rowid')]
-                if foreign_table != tablename and foreign_table + 's' != tablename:
-                    if False:
-                        foreign_body.append(
-                            'FOREIGN KEY (%s) REFERENCES %s (%s)'
-                            % (name, foreign_table, name)
-                        )
-                        coldef_line = '%s %s' % (name, type_)
-                    else:
-                        # alternative way to do this in SQLITE 3
-                        coldef_line = '%s %s REFERENCES %s' % (
-                            name,
-                            type_,
-                            foreign_table,
-                        )
-                    body_list.append(coldef_line)
-                else:
-                    coldef_line = '%s %s' % (name, type_)
-                    body_list.append(coldef_line)
-            else:
-                # else:
-                coldef_line = '%s %s' % (name, type_)
-                body_list.append(coldef_line)
-
-        if self.USE_FOREIGN_HACK:
-            body_list += foreign_body
+            coldef_line = '%s %s' % (name, type_)
+            body_list.append(coldef_line)
 
         sep_ = ',' + sep
         table_body = sep_.join(body_list + constraint_list)

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -488,26 +488,17 @@ class SQLDatabaseController(object):
         self.thread_connections = {}
         self._connection = None
         # FIXME (31-Jul-12020) rename to private attribute, no direct access to the connection
-        self.cur = None
+        # Initialize a cursor
+        self.cur = self.connection.cursor()
 
-        # FIXME (31-Jul-12020) check based on the existance of the metadata table
-        # is_new = True
+        # Ensure the metadata table is initialized.
+        self._ensure_metadata_table()
 
-        # # Optimize the database (if anything is set)
-        # if is_new:
-        #     self.optimize()
+        # TODO (31-Jul-12020) Move to Operations code.
+        #      Optimization is going to depends on the operational deployment of this codebase.
+        # Optimize the database
+        self.optimize()
 
-        # if not is_new:
-        #     # Check for old database versions
-        #     try:
-        #         self.get_db_version(ensure=False)
-        #     except lite.OperationalError:
-        #         always_check_metadata = True
-
-        # if not self.readonly:
-        #     if is_new or always_check_metadata:
-        #         # TODO: make this happen lazilly
-        #         self._ensure_metadata_table()
         return self
 
     def connect(self):

--- a/wbia/tests/dtool/test_sql_control.py
+++ b/wbia/tests/dtool/test_sql_control.py
@@ -21,9 +21,14 @@ def test_instantiation(ctrlr):
 
     # Check for a connection, that would have been made during instantiation
     assert isinstance(ctrlr.connection, sqlite3.Connection)
-    assert ctrlr.cur is None
+    assert isinstance(ctrlr.cur, sqlite3.Cursor)
 
 
-def test_version(ctrlr):
-    v = ctrlr.get_db_version()
+def test_safely_get_db_version(ctrlr):
+    v = ctrlr.get_db_version(ensure=True)
+    assert v == '0.0.0'
+
+
+def test_unsafely_get_db_version(ctrlr):
+    v = ctrlr.get_db_version(ensure=False)
     assert v == '0.0.0'

--- a/wbia/tests/dtool/test_sql_control.py
+++ b/wbia/tests/dtool/test_sql_control.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import sqlite3
+
+import pytest
+
+from wbia.dtool.sql_control import (
+    TIMEOUT,
+    SQLDatabaseController,
+)
+
+
+@pytest.fixture
+def ctrlr():
+    return SQLDatabaseController.from_uri(':memory:')
+
+
+def test_instantiation(ctrlr):
+    # Check for basic connection information
+    assert ctrlr.uri == ':memory:'
+    assert ctrlr.timeout == TIMEOUT
+
+    # Check for a connection, that would have been made during instantiation
+    assert isinstance(ctrlr.connection, sqlite3.Connection)
+    assert ctrlr.cur is None
+
+
+def test_version(ctrlr):
+    v = ctrlr.get_db_version()
+    assert v == '0.0.0'


### PR DESCRIPTION
These changes are mostly around the concept of moving away from a file based instantiation of the SQL Controller object. I'm done this along side the existing code for the moment.

Look through the commits themselves, but the main entrypoint here is the `from_uri` class method, which takes a URI argument. This will migrate us towards utilize sqlite's memory and file based databases as well as a postgres service.
