### PR TITLE
Finding CLI space

### DIFF
--- a/wbia/control/_sql_helpers.py
+++ b/wbia/control/_sql_helpers.py
@@ -262,6 +262,8 @@ def ensure_correct_version(
     from wbia import constants as const
     from wbia import params
 
+    params.parse_args()
+
     # print('[SQL_] ensure_correct_version')
     force_incremental = params.args.force_incremental_db_update
     want_base_version = version_expected == const.BASE_DATABASE_VERSION

--- a/wbia/dev.py
+++ b/wbia/dev.py
@@ -305,6 +305,7 @@ def run_devcmds(ibs, qaid_list, daid_list, acfg=None):
     """
     This function runs tests passed in with the -t flag
     """
+    params.parse_args()
     print('\n')
     # print('[dev] run_devcmds')
     print('==========================')
@@ -710,8 +711,6 @@ def devmain():
         --cmd  # ipython shell to play with variables
         -t     # run list of tests
     """
-    from wbia import params
-
     params.parse_args()
 
     print('DEVMAIN INIT - PRELOGGING')

--- a/wbia/init/main_commands.py
+++ b/wbia/init/main_commands.py
@@ -42,6 +42,7 @@ def vwd():
 def preload_commands(dbdir, **kwargs):
     """ Preload commands work with command line arguments and global caches """
     # print('[main_cmd] preload_commands')
+    params.parse_args()
     if params.args.dump_argv:
         print(ut.repr2(vars(params.args), sorted_=False))
     if params.args.dump_global_cache:
@@ -82,6 +83,7 @@ def postload_commands(ibs, back):
     wbia --db PZ_MTEST --occur "*All Images" --query-intra
 
     """
+    params.parse_args()
     if ut.NOT_QUIET:
         print('\n[main_cmd] postload_commands')
     if params.args.view_database_directory:

--- a/wbia/init/sysres.py
+++ b/wbia/init/sysres.py
@@ -11,7 +11,7 @@ import utool as ut
 import ubelt as ub
 from six.moves import input, zip, map
 from wbia import constants as const
-from wbia import params
+
 
 (print, rrr, profile) = ut.inject2(__name__)
 
@@ -327,11 +327,8 @@ def get_args_dbdir(defaultdb=None, allow_newdir=False, db=None, dbdir=None):
         return dbdir
 
     # Check command line arguments
-    dbdir_arg = params.args.dbdir
-    db_arg = params.args.db
-    # TODO: use these instead of params
-    # ut.get_argval('--dbdir', return_was_specified=True))
-    # ut.get_argval('--db', return_was_specified=True)
+    dbdir_arg = ut.get_argval('--dbdir', default=None)
+    db_arg = ut.get_argval('--db', default=None)
     # Check command line passed args
     dbdir = prioritize(dbdir_arg, db_arg)
     if dbdir is not None:

--- a/wbia/init/sysres.py
+++ b/wbia/init/sysres.py
@@ -307,7 +307,7 @@ def get_args_dbdir(defaultdb=None, allow_newdir=False, db=None, dbdir=None):
         print('[sysres] defaultdb=%r, allow_newdir=%r' % (defaultdb, allow_newdir))
         print('[sysres] db=%r, dbdir=%r' % (db, dbdir))
 
-    def _db_arg_priorty(dbdir_, db_):
+    def prioritize(dbdir_, db_):
         invalid = ['', ' ', '.', 'None']
         # Invalidate bad db's
         if dbdir_ in invalid:
@@ -322,9 +322,9 @@ def get_args_dbdir(defaultdb=None, allow_newdir=False, db=None, dbdir=None):
         return None
 
     # Check function arguments
-    dbdir1 = _db_arg_priorty(dbdir, db)
-    if dbdir1 is not None:
-        return dbdir1
+    dbdir = prioritize(dbdir, db)
+    if dbdir is not None:
+        return dbdir
 
     # Check command line arguments
     dbdir_arg = params.args.dbdir
@@ -333,9 +333,9 @@ def get_args_dbdir(defaultdb=None, allow_newdir=False, db=None, dbdir=None):
     # ut.get_argval('--dbdir', return_was_specified=True))
     # ut.get_argval('--db', return_was_specified=True)
     # Check command line passed args
-    dbdir2 = _db_arg_priorty(dbdir_arg, db_arg)
-    if dbdir2 is not None:
-        return dbdir2
+    dbdir = prioritize(dbdir_arg, db_arg)
+    if dbdir is not None:
+        return dbdir
 
     # Return cached database directory
     if defaultdb is None:

--- a/wbia/main_module.py
+++ b/wbia/main_module.py
@@ -13,6 +13,9 @@ import multiprocessing
 # try:
 import utool as ut
 
+from wbia import params
+
+
 profile = ut.profile
 # profile = getattr(builtins, 'profile')
 # except AttributeError:
@@ -56,12 +59,6 @@ def _reset_signals():
     signal.signal(signal.SIGINT, signal.SIG_DFL)  # reset ctrl+c behavior
 
 
-def _parse_args():
-    from wbia import params
-
-    params.parse_args()
-
-
 def _init_matplotlib():
     from wbia.plottool import __MPL_INIT__
 
@@ -92,7 +89,8 @@ def _init_wbia(dbdir=None, verbose=None, use_cache=True, web=None, **kwargs):
     Private function that calls code to create an wbia controller
     """
     import utool as ut
-    from wbia import params
+
+    params.parse_args()
     from wbia.control import IBEISControl
 
     if verbose is None:
@@ -133,7 +131,8 @@ def _init_parallel():
     if ut.VERBOSE:
         print('_init_parallel')
     from utool import util_parallel
-    from wbia import params
+
+    params.parse_args()
 
     # Import any modules which parallel process will use here
     # so they are accessable when the program forks
@@ -634,13 +633,13 @@ def _preload(mpl=True, par=True, logging=True):
     import utool as ut
 
     # from wbia.init import main_helpers
-    # from wbia import params
+    # params.parse_args()
     # from wbia.init import sysres
     if multiprocessing.current_process().name != 'MainProcess':
         return
     if ut.VERBOSE:
         print('[wbia] _preload')
-    _parse_args()
+    params.parse_args()
     # mpl backends
     # if logging and not params.args.nologging:
     #     if params.args.logdir is not None:
@@ -685,7 +684,7 @@ def main_loop(main_locals, rungui=True, ipy=False, persist=True):
         str: execstr
     """
     print('[main] wbia.main_module.main_loop()')
-    from wbia import params
+    params.parse_args()
     import utool as ut
 
     # print('current process = %r' % (multiprocessing.current_process().name,))

--- a/wbia/params.py
+++ b/wbia/params.py
@@ -27,7 +27,7 @@ nnkj/enerate this module automagically from
 from __future__ import absolute_import, division, print_function
 from utool import util_arg
 import utool as ut
-import os
+
 
 (print, rrr, profile) = ut.inject2(__name__)
 
@@ -231,12 +231,3 @@ def parse_args():
     args.gui = not args.nogui
     if args.serial:
         args.num_procs = 1
-
-
-# Dont parse args if environment variable is off
-# We use this to turn off arg parsing when Sphinx is running
-if (
-    os.environ.get('IBIES_PARSE_ARGS', 'ON') == 'ON'
-    and os.environ.get('UTOOL_AUTOGEN_SPHINX_RUNNING', 'OFF') == 'OFF'
-):
-    parse_args()

--- a/wbia/tests/init/test_sysres.py
+++ b/wbia/tests/init/test_sysres.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import sys
+
 import pytest
 
 from wbia import sysres
@@ -52,14 +54,14 @@ class TestGetArgsDbdir:
 
     def test_cli_db(self, monkeypatch):
         target = 'foo'
-        monkeypatch.setattr(sysres.params.args, 'db', target)
+        monkeypatch.setattr(sys, 'argv', ['--db', target])
         # ... then command line arguments are used.
         d = get_args_dbdir(None, False, None, None)
         assert d == self.get_db_to_dbdir_marked(target)
 
     def test_cli_dbdir(self, monkeypatch):
         target = 'foo'
-        monkeypatch.setattr(sysres.params.args, 'dbdir', target)
+        monkeypatch.setattr(sys, 'argv', ['--dbdir', target])
         # ... then command line arguments are used.
         d = get_args_dbdir(None, False, None, None)
         assert d == self.get_realpath_marked(target)

--- a/wbia/tests/init/test_sysres.py
+++ b/wbia/tests/init/test_sysres.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from wbia import sysres
+from wbia.init.sysres import get_args_dbdir
+
+
+class TestGetArgsDbdir:
+    # Monkeypatches functions used within get_args_dbdir to scope things.
+    # Tests verify it passes through the correct function by marking the results.
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch):
+        monkeypatch.setattr(sysres, 'db_to_dbdir', self.monkey_db_to_dbdir)
+        monkeypatch.setattr(sysres, 'realpath', self.monkey_realpath)
+
+    DB_MARK = '%'
+    PATH_MARK = '!'
+
+    def monkey_db_to_dbdir(self, db, **kwargs):
+        # Just mark that we've seen it.
+        # Ignorant of kwargs, noqa!
+        return self.get_db_to_dbdir_marked(db)
+
+    def monkey_realpath(self, path):
+        # Just mark that we've seen it.
+        return self.get_realpath_marked(path)
+
+    def get_db_to_dbdir_marked(self, x):
+        return f'{x}{self.DB_MARK}'
+
+    def get_realpath_marked(self, x):
+        return f'{x}{self.PATH_MARK}'
+
+    def test_no_args(self):
+        try:
+            get_args_dbdir()
+        except ValueError as exc:
+            assert exc.args[0] == 'Must specify at least db, dbdir, or defaultdb'
+
+    def test_db_arg(self):
+        # The function first defaults to the specified function arguments.
+        target = 'testdb1'
+        d = get_args_dbdir(None, False, target, None)
+        assert d == self.get_db_to_dbdir_marked(target)
+
+    def test_dbdir_arg(self):
+        # The function first defaults to the specified function arguments.
+        target = 'foo'
+        d = get_args_dbdir(None, False, None, target)
+        assert d == self.get_realpath_marked(target)
+
+    def test_cli_db(self, monkeypatch):
+        target = 'foo'
+        monkeypatch.setattr(sysres.params.args, 'db', target)
+        # ... then command line arguments are used.
+        d = get_args_dbdir(None, False, None, None)
+        assert d == self.get_db_to_dbdir_marked(target)
+
+    def test_cli_dbdir(self, monkeypatch):
+        target = 'foo'
+        monkeypatch.setattr(sysres.params.args, 'dbdir', target)
+        # ... then command line arguments are used.
+        d = get_args_dbdir(None, False, None, None)
+        assert d == self.get_realpath_marked(target)
+
+    def test_defaultdb(self):
+        target = 'foo'
+        # In all other circumstances defaultdb is used.
+        d = get_args_dbdir(defaultdb=target)
+        assert d == self.get_db_to_dbdir_marked(target)
+
+    def test_defaultdb_cache(self, monkeypatch):
+        # Monkeypatch the target function to guarantee the result.
+        target = '<monkey>'
+        monkeypatch.setattr(sysres, 'get_default_dbdir', lambda: target)
+
+        # If defaultdb='cache' then the most recently used database directory is returned.
+        d = get_args_dbdir(defaultdb='cache')
+        assert d == target


### PR DESCRIPTION
This set of changes attempts to find interface space. I'm gaining this interface space by replacing `wbia.params`'s implicit "on import" behavior that populates the `args` variable. I've changed the behavior to an explicit one, where the user of the `wbia.params.args` must call `wbia.params.parse_args`. This allows the current logic to continue working while opening up interface space where other scripts can make their own arguments (or more specifically use `--help` in the script).

