### PR TITLE
Clean up entry point's module

### DIFF
--- a/wbia/__init__.py
+++ b/wbia/__init__.py
@@ -39,7 +39,7 @@ if ut.is_developer():
 # If we dont initialize plottool before <something>
 # then it causes a crash in windows. Its so freaking weird.
 # something is not guitool, wbia.viz
-# has to be before control, can be after constants, params, and main_module
+# has to be before control, can be after constants, params, and entry_points
 # import wbia.plottool
 
 
@@ -50,11 +50,11 @@ try:
     from wbia import constants
     from wbia import constants as const
     from wbia import params
-    from wbia import main_module
+    from wbia import entry_points
     from wbia import other
     from wbia.init import sysres
 
-    # main_module._preload()
+    # entry_points._preload()
 
     from wbia import control
     from wbia import dbio
@@ -62,7 +62,7 @@ try:
     # from wbia import web
 
     from wbia.init import sysres
-    from wbia.main_module import (
+    from wbia.entry_points import (
         main,
         _preload,
         _init_numpy,
@@ -355,7 +355,7 @@ def reload_subs(verbose=True):
     import_subs()
     rrr(verbose=verbose)
     getattr(constants, 'rrr', lambda verbose: None)(verbose=verbose)
-    getattr(main_module, 'rrr', lambda verbose: None)(verbose=verbose)
+    getattr(entry_points, 'rrr', lambda verbose: None)(verbose=verbose)
     getattr(params, 'rrr', lambda verbose: None)(verbose=verbose)
     getattr(other, 'reload_subs', lambda verbose: None)(verbose=verbose)
     getattr(dbio, 'reload_subs', lambda verbose: None)(verbose=verbose)
@@ -381,5 +381,5 @@ Regen Command:
 
     cd /home/joncrall/code/wbia/wbia/other
     makeinit.py -x web viz tests gui
-    makeinit.py -x constants params main_module other control dbio tests
+    makeinit.py -x constants params entry_points other control dbio tests
 """

--- a/wbia/__main__.py
+++ b/wbia/__main__.py
@@ -10,7 +10,7 @@ import ubelt as ub
 import sys
 
 from wbia.dev import devmain
-from wbia.main_module import main, main_loop
+from wbia.entry_points import main, main_loop
 from wbia.scripts.rsync_wbiadb import rsync_ibsdb_main
 
 

--- a/wbia/__main__.py
+++ b/wbia/__main__.py
@@ -19,27 +19,6 @@ from wbia.scripts.rsync_wbiadb import rsync_ibsdb_main
 CMD = ub.argflag('--cmd')
 
 
-def dependencies_for_myprogram():
-    """ Let pyintaller find these modules
-
-    References:
-        http://stackoverflow.com/questions/18596410/importerror-no-module-named-mpl-toolkits-with-maptlotlib-1-3-0-and-py2exe
-    """
-    from wbia.guitool.__PYQT__ import QtCore, QtGui  # Pyinstaller hacks  # NOQA
-
-    # from PyQt4 import QtCore, QtGui  # NOQA
-    # from PyQt4 import QtCore, QtGui  # NOQA
-    from scipy.sparse.csgraph import _validation  # NOQA
-    from scipy.special import _ufuncs_cxx  # NOQA
-    from mpl_toolkits.axes_grid1 import make_axes_locatable  # NOQA
-
-    # import lru  # NOQA
-    # Workaround for mpl_toolkits
-    import importlib
-
-    importlib.import_module('mpl_toolkits').__path__
-
-
 # FIXME (27-Jul-12020) This is currently used by CI to verify installation.
 #       Either make this the main function or move to location that makes sense.
 def smoke_test():  # nocover

--- a/wbia/control/controller_inject.py
+++ b/wbia/control/controller_inject.py
@@ -123,7 +123,7 @@ STRICT_VERSION_API = (
 
 
 def get_flask_app(templates_auto_reload=True):
-    # TODO this should be initialized explicity in main_module.py only if needed
+    # TODO this should be initialized explicity in entry_points.py only if needed
     global GLOBAL_APP
     global GLOBAL_CORS
     global GLOBAL_CAS

--- a/wbia/entry_points.py
+++ b/wbia/entry_points.py
@@ -22,7 +22,7 @@ USE_GUI = '--gui' in sys.argv or '--nogui' not in sys.argv
 
 def _on_ctrl_c(signal, frame):
     proc_name = multiprocessing.current_process().name
-    print('[wbia.main_module] Caught ctrl+c in %s' % (proc_name,))
+    print('[wbia.entry_points] Caught ctrl+c in %s' % (proc_name,))
     sys.exit(0)
 
 
@@ -183,11 +183,11 @@ def set_newfile_permissions():
     sets this processes default permission bits when creating new files
 
     CommandLine:
-        python -m wbia.main_module --test-set_newfile_permissions
+        python -m wbia.entry_points --test-set_newfile_permissions
 
     Example:
         >>> # ENABLE_DOCTEST
-        >>> from wbia.main_module import *  # NOQA
+        >>> from wbia.entry_points import *  # NOQA
         >>> import os
         >>> import utool as ut
         >>> # write before umask
@@ -260,7 +260,7 @@ def main(
     ibs = None
     back = None
     if NOT_QUIET:
-        print('[main] wbia.main_module.main()')
+        print('[main] wbia.entry_points.main()')
     DIAGNOSTICS = NOT_QUIET
     if DIAGNOSTICS:
         import os
@@ -347,11 +347,11 @@ def opendb_bg_web(*args, managed=False, **kwargs):
         web_ibs - this is a KillableProcess object with special functions
 
     CommandLine:
-        python -m wbia.main_module opendb_bg_web
+        python -m wbia.entry_points opendb_bg_web
 
     Example:
         >>> # DISABLE_DOCTEST
-        >>> from wbia.main_module import *  # NOQA
+        >>> from wbia.entry_points import *  # NOQA
         >>> args = tuple()
         >>> kwargs = {}
         >>> print('Opening a web_ibs')
@@ -495,7 +495,7 @@ def opendb_bg_web(*args, managed=False, **kwargs):
 def opendb_fg_web(*args, **kwargs):
     """
     Ignore:
-        >>> from wbia.main_module import *  # NOQA
+        >>> from wbia.entry_points import *  # NOQA
         >>> kwargs = {'db': 'testdb1'}
         >>> args = tuple()
 
@@ -549,7 +549,7 @@ def opendb(
 
     Example:
         >>> # ENABLE_DOCTEST
-        >>> from wbia.main_module import *  # NOQA
+        >>> from wbia.entry_points import *  # NOQA
         >>> db = None
         >>> dbdir = None
         >>> defaultdb = 'cache'
@@ -649,7 +649,7 @@ def main_loop(main_locals, rungui=True, ipy=False, persist=True):
     Returns:
         str: execstr
     """
-    print('[main] wbia.main_module.main_loop()')
+    print('[main] wbia.entry_points.main_loop()')
     params.parse_args()
     import utool as ut
 

--- a/wbia/gui/guiback.py
+++ b/wbia/gui/guiback.py
@@ -4196,7 +4196,7 @@ def testdata_guiback(defaultdb='testdb2', **kwargs):
 
     print('testdata guiback')
     if defaultdb is None:
-        back = wbia.main_module._init_gui()
+        back = wbia.entry_points_init_gui()
         # back = MainWindowBackend()
     else:
         main_locals = wbia.main(defaultdb=defaultdb, **kwargs)

--- a/wbia/init/main_commands.py
+++ b/wbia/init/main_commands.py
@@ -196,51 +196,6 @@ def postload_commands(ibs, back):
     if ut.get_argflag('--graph'):
         back.make_qt_graph_interface()
 
-    screengrab_fpath = ut.get_argval('--screengrab')
-    if screengrab_fpath:
-        from wbia.guitool.__PYQT__.QtGui import QPixmap
-        from PyQt4.QtTest import QTest
-        from PyQt4.QtCore import Qt
-
-        fpath = ut.truepath(screengrab_fpath)
-        from wbia import guitool
-
-        # ut.embed()
-        timer2 = guitool.__PYQT__.QtCore.QTimer()
-        done = [1000]
-
-        def delayed_screenshot_func():
-            if done[0] == 500:
-                # back.mainwin.menubar.triggered.emit(back.mainwin.menuFile)
-                print('Mouseclick')
-                QTest.mouseClick(back.mainwin.menuFile, Qt.LeftButton)
-                # This works
-                # QTest.mouseClick(back.front.import_button, Qt.LeftButton)
-            if done[0] == 1:
-                timer2.stop()
-                print('screengrab to %r' % (fpath,))
-                screenimg = QPixmap.grabWindow(back.mainwin.winId())
-                screenimg.save(fpath, 'jpg')
-                ut.startfile(fpath)
-                print('lub dub2')
-            done[0] -= 1
-            return None
-
-        CLICK_FILE_MENU = True
-        if CLICK_FILE_MENU:
-            # ut.embed()
-            # QTest::keyClick(menu, Qt::Key_Down)
-            pass
-        timer2.delayed_screenshot_func = delayed_screenshot_func
-        timer2.timeout.connect(timer2.delayed_screenshot_func)
-        timer2.start(1)
-        back.mainwin.timer2 = timer2
-        guitool.activate_qwindow(back.mainwin)
-        # QPixmap.grabWindow(back.mainwin.winId()).save(fpath, 'jpg')
-        # ut.startfile(fpath)
-        # ut.embed()
-        pass
-
     if params.args.postload_exit:
         print('[main_cmd] postload exit')
         sys.exit(0)

--- a/wbia/main_module.py
+++ b/wbia/main_module.py
@@ -5,22 +5,16 @@ wbia.opendb and wbia.main are the main entry points
 """
 from __future__ import absolute_import, division, print_function
 
-# from six.moves import builtins
 from contextlib import contextmanager
 import sys
 import multiprocessing
 
-# try:
 import utool as ut
 
 from wbia import params
 
 
 profile = ut.profile
-# profile = getattr(builtins, 'profile')
-# except AttributeError:
-# def profile(func):
-#    return func
 
 QUIET = '--quiet' in sys.argv
 NOT_QUIET = not QUIET
@@ -34,13 +28,6 @@ def _on_ctrl_c(signal, frame):
     proc_name = multiprocessing.current_process().name
     print('[wbia.main_module] Caught ctrl+c in %s' % (proc_name,))
     sys.exit(0)
-    # try:
-    #     _close_parallel()
-    # except Exception as ex:
-    #     print('Something very bad happened' + repr(ex))
-    # finally:
-    #     print('[wbia.main_module] sys.exit(0)')
-    #     sys.exit(0)
 
 
 # -----------------------
@@ -71,14 +58,9 @@ def _init_gui(activate=True):
     if NOT_QUIET:
         print('[main] _init_gui()')
     guitool.ensure_qtapp()
-    # USE_OLD_BACKEND = '--old-backend' in sys.argv
-    # if USE_OLD_BACKEND:
     from wbia.gui import guiback
 
     back = guiback.MainWindowBackend()
-    # else:
-    #    from wbia.gui import newgui
-    #    back = newgui.IBEISGuiWidget()
     if activate:
         guitool.activate_qwindow(back.mainwin)
     return back
@@ -148,18 +130,6 @@ def _init_parallel():
     util_parallel.set_num_procs(params.args.num_procs)
     # if PREINIT_MULTIPROCESSING_POOLS:
     #    util_parallel.init_pool(params.args.num_procs)
-
-
-# def _close_parallel():
-#     #if ut.VERBOSE:
-#     #    print('_close_parallel')
-#     try:
-#         from utool import util_parallel
-#         util_parallel.close_pool(terminate=True)
-#     except Exception as ex:
-#         import utool as ut
-#         ut.printex(ex, 'error closing parallel')
-#         raise
 
 
 def _init_numpy():
@@ -705,12 +675,4 @@ def main_loop(main_locals, rungui=True, ipy=False, persist=True):
 
 
 def main_close(main_locals=None):
-    # import utool as ut
-    # if ut.VERBOSE:
-    #    print('main_close')
-    # _close_parallel()
     _reset_signals()
-
-
-# if __name__ == '__main__':
-#    multiprocessing.freeze_support()

--- a/wbia/main_module.py
+++ b/wbia/main_module.py
@@ -12,14 +12,12 @@ import utool as ut
 from wbia import params
 
 
-profile = ut.profile
-
 QUIET = '--quiet' in sys.argv
 NOT_QUIET = not QUIET
 USE_GUI = '--gui' in sys.argv or '--nogui' not in sys.argv
 
 
-(print, rrr, profile) = ut.inject2(__name__)
+(print, _, __) = ut.inject2(__name__)
 
 
 def _on_ctrl_c(signal, frame):

--- a/wbia/main_module.py
+++ b/wbia/main_module.py
@@ -3,11 +3,9 @@
 This module defines the entry point into the IBEIS system
 wbia.opendb and wbia.main are the main entry points
 """
-from __future__ import absolute_import, division, print_function
-
-from contextlib import contextmanager
 import sys
 import multiprocessing
+from contextlib import contextmanager
 
 import utool as ut
 

--- a/wbia/tests/run_tests.py
+++ b/wbia/tests/run_tests.py
@@ -65,7 +65,7 @@ def static_doctest_modnames():
         'wbia',
         'wbia.annots',
         'wbia.core_annots',
-        'wbia.main_module',
+        'wbia.entry_points',
         'wbia.new_annots',
         'wbia.tag_funcs',
         'wbia.core_images',


### PR DESCRIPTION
This set of changes cleans up the main entry-points module by removing older code and organizing some of the existing code.

I've renamed `main_module` to `entry_points` because the term 'main' seems a bit overloaded, especially with the presents of `__main__` in the package. I anticipate the module will become very lean, and possibly renamed once again, after we've pulled or cleaned up the GUI logic within it.

Note, these changes were made across a series of different branches I've created. I've lumped them together into this branch as a set of clean up changes.