### PR TITLE
Clean up the method that makes CREATE TABLE SQL statements

### DIFF
--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -1629,15 +1629,13 @@ class SQLDatabaseController(object):
         operation = op_fmtstr.format(**fmtkw)
         self.executeone(operation, [], verbose=False)
 
-    def _make_add_table_sqlstr(
-        self, tablename=None, coldef_list=None, sep=' ', **metadata_keyval
-    ):
+    def _make_add_table_sqlstr(self, tablename, coldef_list, sep=' ', **metadata_keyval):
         r"""
         TODO: Foreign keys and indexed columns
 
         Args:
-            tablename (None): (default = None)
-            coldef_list (list): (default = None)
+            tablename (str): table name
+            coldef_list (list): list of tuples (name, type definition)
 
         Returns:
             str: operation
@@ -1656,14 +1654,12 @@ class SQLDatabaseController(object):
             >>> coldef_list = autogen_dict['coldef_list']
             >>> operation = db._make_add_table_sqlstr(tablename, coldef_list)
             >>> print(operation)
+
         """
-        if len(coldef_list) == 0 or coldef_list is None:
-            raise AssertionError('table %s is not given any columns' % (tablename,))
         bad_kwargs = set(metadata_keyval.keys()) - set(METADATA_TABLE_COLUMN_NAMES)
         assert (
             len(bad_kwargs) == 0
         ), 'keyword args specified that are not metadata keys=%r' % (bad_kwargs,)
-        assert tablename is not None, 'tablename must be given'
         if ut.DEBUG2:
             print('[sql] schema ensuring tablename=%r' % tablename)
         if ut.VERBOSE:


### PR DESCRIPTION
I was trying to make sense of some of the things happening in this
method. Best way for me to do that was to clean it up.

The method now has required arguments, which were basically required
arguments given all the checking that was happening in the method
itself. This also make them typed arguments to remove the additional
type checking in method. I've kept the value checking, but made these
`ValueError`s rather than `AssertionError`s, which is typically what they
should be.

The method AFAICT behaves the exact same way as before, it's just
easier to read and anticipate what it is doing.