### PR TITLE
Fix some web tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -238,11 +238,11 @@ Our code uses Google-style documentation tests (doctests) that uses pytest and x
 
     pytest
 
-To run doctests with `+REQUIRES(--web)` do:
+To run doctests with `+REQUIRES(--web-tests)` do:
 
 .. code:: bash
 
-    pytest --web
+    pytest --web-tests
 
 .. |Build| image:: https://img.shields.io/github/workflow/status/WildbookOrg/wildbook-ia/Build%20and%20upload%20to%20PyPI/master
     :target: https://github.com/WildbookOrg/wildbook-ia/actions?query=branch%3Amaster+workflow%3A%22Build+and+upload+to+PyPI%22

--- a/_dev/update_wbia2_tooling.sh
+++ b/_dev/update_wbia2_tooling.sh
@@ -41,4 +41,4 @@ sedr_python "from vtool._pyflann_backend" "from vtool_ibeis._pyflann_backend" $L
 
 
 sedr_python "# GUI_DOCTEST" "# xdoctest: +REQUIRES(--gui)" True
-sedr_python "# WEB_DOCTEST" "# xdoctest: +REQUIRES(--web)" True
+sedr_python "# WEB_DOCTEST" "# xdoctest: +REQUIRES(--web-tests)" True

--- a/conftest.py
+++ b/conftest.py
@@ -6,5 +6,5 @@ def pytest_addoption(parser):
     parser.addoption('--gui', action='store_true')
     parser.addoption('--show', action='store_true')
     parser.addoption('--tomcat', action='store_true')
-    parser.addoption('--web', action='store_true')
+    parser.addoption('--web-tests', action='store_true')
     parser.addoption('--weird', action='store_true')

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -1144,7 +1144,7 @@ class IBEISController(BASE_CLASS):
             python -m wbia.control.IBEISControl --exec-get_current_log_text --domain http://52.33.105.88
 
         Example:
-            >>> # xdoctest: +REQUIRES(--web)
+            >>> # xdoctest: +REQUIRES(--web-tests)
             >>> from wbia.control.IBEISControl import *  # NOQA
             >>> import wbia
             >>> import wbia.web

--- a/wbia/control/controller_inject.py
+++ b/wbia/control/controller_inject.py
@@ -496,18 +496,17 @@ def translate_wbia_webcall(func, *args, **kwargs):
         >>> import wbia
         >>> import time
         >>> import wbia.web
-        >>> web_ibs = wbia.opendb_bg_web('testdb1', wait=1, start_job_queue=False)
-        >>> aids = web_ibs.send_wbia_request('/api/annot/', 'get')
-        >>> uuid_list = web_ibs.send_wbia_request('/api/annot/uuids/', aid_list=aids)
-        >>> failrsp = web_ibs.send_wbia_request('/api/annot/uuids/')
-        >>> failrsp2 = web_ibs.send_wbia_request('/api/query/chips/simple_dict//', 'get', qaid_list=[0], daid_list=[0])
-        >>> log_text = web_ibs.send_wbia_request('/api/query/chips/simple_dict/', 'get', qaid_list=[0], daid_list=[0])
+        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
+        ...     aids = web_ibs.send_wbia_request('/api/annot/', 'get')
+        ...     uuid_list = web_ibs.send_wbia_request('/api/annot/uuids/', aid_list=aids, json=False)
+        ...     failrsp = web_ibs.send_wbia_request('/api/annot/uuids/', json=False)
+        ...     failrsp2 = web_ibs.send_wbia_request('/api/query/chips/simple_dict//', 'get', qaid_list=[0], daid_list=[0], json=False)
+        ...     log_text = web_ibs.send_wbia_request('/api/query/chips/simple_dict/', 'get', qaid_list=[0], daid_list=[0], json=False)
         >>> time.sleep(.1)
         >>> print('\n---\nuuid_list = %r' % (uuid_list,))
         >>> print('\n---\nfailrsp =\n%s' % (failrsp,))
         >>> print('\n---\nfailrsp2 =\n%s' % (failrsp2,))
         >>> print('Finished test')
-        >>> web_ibs.terminate2()
 
     Ignore:
         app = get_flask_app()

--- a/wbia/control/controller_inject.py
+++ b/wbia/control/controller_inject.py
@@ -491,7 +491,7 @@ def translate_wbia_webcall(func, *args, **kwargs):
         python -m wbia.control.controller_inject --exec-translate_wbia_webcall --domain http://52.33.105.88
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.control.controller_inject import *  # NOQA
         >>> import wbia
         >>> import time

--- a/wbia/entry_points.py
+++ b/wbia/entry_points.py
@@ -441,7 +441,7 @@ def opendb_bg_web(*args, managed=False, **kwargs):
             status_response = web_ibs.send_wbia_request(
                 '/api/engine/job/status/', jobid=jobid
             )
-            if status_response['jobstatus'] == 'completed':
+            if status_response['jobstatus'] in ('completed', 'exception'):
                 break
         return status_response
 

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -66,7 +66,7 @@ def image_src_api(rowid=None, thumbnail=False, fresh=False, **kwargs):
     Returns the image file of image <gid>
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
@@ -217,7 +217,7 @@ def image_src_api_json(uuid=None, **kwargs):
     Returns the image file of image <gid>
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
@@ -427,7 +427,7 @@ def hello_world(*args, **kwargs):
         python -m wbia.web.apis --exec-hello_world:1
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> web_ibs = wbia.opendb_bg_web(browser=True, start_job_queue=False, url_suffix='/api/test/helloworld/?test0=0')  # start_job_queue=False)
@@ -436,7 +436,7 @@ def hello_world(*args, **kwargs):
         >>> web_ibs.terminate2()
 
     Example1:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> import requests

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -259,7 +259,7 @@ def start_identify_annots(
         >>> cm_list = qreq_.execute()
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.apis_engine import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -283,6 +283,11 @@ def start_identify_annots(
         ...     cm_dict = result_response['json_result'][0]
         ...     print('Finished test')
         ...     bgserver.terminate2()
+        Waiting for server to be up. count=0
+        ...
+        status_response = {'status': 'ok', 'jobid': '...', 'jobstatus': 'completed'}
+        result_response = ...
+        Finished test
 
     Ignore:
         qaids = daids = ibs.get_valid_aids()

--- a/wbia/web/apis_json.py
+++ b/wbia/web/apis_json.py
@@ -370,21 +370,6 @@ def add_images_json(
         >>>             'key'             : '3/a/3a76b0e8-1c64-403d-ace1-679cf2f081c0/f2.jpg',
         >>>         },
         >>>     ],
-        >>>     'image_uuid_list': [
-        >>>         uuid.uuid4(),
-        >>>         uuid.uuid4(),
-        >>>         uuid.uuid4(),
-        >>>     ],
-        >>>     'image_width_list': [
-        >>>         1992,
-        >>>         1194,
-        >>>         500,
-        >>>     ],
-        >>>     'image_height_list': [
-        >>>         1328,
-        >>>         401,
-        >>>         500,
-        >>>     ],
         >>> }
         >>> gid_list = wbia.web.apis_json.add_images_json(web_instance, **_payload)
         >>> print(gid_list)

--- a/wbia/web/apis_json.py
+++ b/wbia/web/apis_json.py
@@ -353,7 +353,7 @@ def add_images_json(
         ,"bucket":"flukebook-prod-asset-store","key":""
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.control.IBEISControl import *  # NOQA
         >>> import wbia
         >>> import uuid

--- a/wbia/web/apis_json.py
+++ b/wbia/web/apis_json.py
@@ -353,7 +353,8 @@ def add_images_json(
         ,"bucket":"flukebook-prod-asset-store","key":""
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web-tests)
+        >>> # FIXME failing-test (03-Aug-2020) boto.exception.NoAuthHandlerFound: No handler was ready to authenticate
+        >>> # xdoctest: +SKIP
         >>> from wbia.control.IBEISControl import *  # NOQA
         >>> import wbia
         >>> import uuid

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -91,7 +91,8 @@ def query_chips_simple_dict(ibs, *args, **kwargs):
         >>> print(result)
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web-tests)
+        >>> # xdoctest: +SKIP
+        >>> # FIXME failing-test (04-Aug-2020) This test hangs when running together with the test above
         >>> from wbia.control.IBEISControl import *  # NOQA
         >>> import wbia
         >>> # Start up the web instance

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -93,22 +93,11 @@ def query_chips_simple_dict(ibs, *args, **kwargs):
     Example:
         >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.control.IBEISControl import *  # NOQA
-        >>> import time
         >>> import wbia
-        >>> import requests
         >>> # Start up the web instance
-        >>> web_instance = wbia.opendb_in_background(db='testdb1', web=True, browser=False)
-        >>> time.sleep(10)
-        >>> web_port = ibs.get_web_port_via_scan()
-        >>> if web_port is None:
-        >>>     raise ValueError('IA web server is not running on any expected port')
-        >>> baseurl = 'http://127.0.1.1:%s' % (web_port, )
-        >>> data = dict(qaid_list=[1])
-        >>> resp = requests.get(baseurl + '/api/query/chip/simple/dict/', data=data)
-        >>> print(resp)
-        >>> web_instance.terminate()
-        >>> json_dict = resp.json()
-        >>> cmdict_list = json_dict['response']
+        >>> with wbia.opendb_bg_web(db='testdb1', managed=True) as web_ibs:
+        ...     cmdict_list = web_ibs.send_wbia_request('/api/query/chip/dict/simple/', type_='get', qaid_list=[1], daid_list=[1, 2, 3])
+        >>> print(cmdict_list)
         >>> assert 'score_list' in cmdict_list[0]
 
     """

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -1292,8 +1292,8 @@ def query_chips(
     # The qaid and daid objects are allowed to be None if qreq_ is
     # specified
     if qreq_ is None:
-        assert qaid_list is not None, 'do not specify qaids and qreq'
-        assert daid_list is not None, 'do not specify daids and qreq'
+        assert qaid_list is not None, 'Need to specify qaids'
+        assert daid_list is not None, 'Need to specify daids'
         qaid_list, was_scalar = ut.wrap_iterable(qaid_list)
         if daid_list is None:
             daid_list = ibs.get_valid_aids()

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -69,7 +69,7 @@ def query_chips_simple_dict(ibs, *args, **kwargs):
         python -m wbia.web.apis_query --test-query_chips_simple_dict:0 --humpbacks
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.control.IBEISControl import *  # NOQA
         >>> import wbia
         >>> ibs = wbia.opendb(defaultdb='testdb1')
@@ -91,7 +91,7 @@ def query_chips_simple_dict(ibs, *args, **kwargs):
         >>> print(result)
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.control.IBEISControl import *  # NOQA
         >>> import time
         >>> import wbia
@@ -333,7 +333,7 @@ def review_graph_match_html(
         python -m wbia.web.apis_query review_graph_match_html --show --domain=localhost
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.apis_query import *  # NOQA
         >>> import wbia
         >>> web_ibs = wbia.opendb_bg_web('testdb1')  # , domain='http://52.33.105.88')
@@ -1413,7 +1413,7 @@ def query_chips_graph_v2(
         python -m wbia --db PZ_MTEST --web --browser --url=/turk/identification/graph/
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.apis_query import *
         >>> import wbia
         >>> # Open local instance

--- a/wbia/web/job_engine.py
+++ b/wbia/web/job_engine.py
@@ -174,7 +174,7 @@ def initialize_job_manager(ibs):
         >>> print('Closing success.')
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> import requests
@@ -263,7 +263,7 @@ def get_job_id_list(ibs):
         python -m wbia.web.job_engine --exec-get_job_status:0 --fg
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
@@ -305,7 +305,7 @@ def get_job_status(ibs, jobid=None):
         python -m wbia.web.job_engine --exec-get_job_status:0 --fg
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')

--- a/wbia/web/test_api.py
+++ b/wbia/web/test_api.py
@@ -86,7 +86,7 @@ def run_test_api():
         python -m wbia.web.test_api --test-run_test_api
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.test_api import *  # NOQA
         >>> response = run_test_api()
         >>> print('Server response: %r' % (response, ))


### PR DESCRIPTION
- Change all +REQUIRES(--web) in tests to --web-tests

  Doing `pytest --web` appears to start the wbia web server instead of
  running the `+REQUIRES(--web)` tests.  Changing `--web` to `--web-tests`
  fix the problem.

- Fix control/controller_inject.py::translate_wbia_webcall:0 test

  1. Remove `wait` from `opendb_bg_web`:
  
     ```
     DOCTEST TRACEBACK
     Traceback (most recent call last):
       File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 556, in run
         exec(code, test_globals)
       File "<doctest:/wbia/wildbook-ia/wbia/control/controller_inject.py::translate_wbia_webcall:0>", line rel: 6, abs: 499, in <module>
         >>> web_ibs = wbia.opendb_bg_web('testdb1', wait=1, start_job_queue=False)
       File "/wbia/wildbook-ia/wbia/main_module.py", line 415, in opendb_bg_web
         web_ibs = opendb_in_background(*args, **_kw)
       File "/wbia/wildbook-ia/wbia/main_module.py", line 358, in opendb_in_background
         raise AssertionError('wait is depricated')
     AssertionError: wait is depricated
     ```
  
  2. Switch test to use `opendb_bg_web` context manager so even if the
     test fails, the server terminates.
  
  3. Change the apis that return non json responses to use `json=False` to
     fix the following error:
  
     ```
      DOCTEST TRACEBACK
      Traceback (most recent call last):
        File "/wbia/wildbook-ia/wbia/main_module.py", line 459, in send_wbia_request
          content = ut.from_json(content)
        File "/wbia/utool/utool/util_cache.py", line 677, in from_json
          val = json.loads(json_str, object_hook=object_hook)
        File "/usr/lib/python3.6/json/__init__.py", line 367, in loads
          return cls(**kw).decode(s)
        File "/usr/lib/python3.6/json/decoder.py", line 339, in decode
          obj, end = self.raw_decode(s, idx=_w(s, 0).end())
        File "/usr/lib/python3.6/json/decoder.py", line 357, in raw_decode
          raise JSONDecodeError("Expecting value", s, err.value) from None
      json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
      ```

- opendb_bg_web.wait_for_results to return if jobstatus=exception

  `opendb_bg_web.wait_for_results` only exits if `jobstatus` is
  `completed` but if it's an `exception`, it continues the infinite loop.
  This happens when running the test
  `wbia/web/apis_engine.py::start_identify_annots:2`.

- Fix wbia/web/apis_engine.py::start_identify_annots:2 test

  Add expected output to wbia/web/apis_engine.py::start_identify_annots:2
  test so we can assert the job actually completed.
  
  The job ended with an exception originally:
  
  ```
  <!!! EXCEPTION !!!>
  Traceback (most recent call last):                                                                                                                   File "/wbia/wildbook-ia/wbia/web/job_engine.py", line 1472, in on_engine_request
      result = action_func(*args, **kwargs)
    File "/wbia/wildbook-ia/wbia/web/apis_query.py", line 116, in query_chips_simple_dict
      return ibs.query_chips(*args, **kwargs)
  TypeError: query_chips() got an unexpected keyword argument \'__jobid__\'
  
  [!on_engine_request] [!?] Caught exception
  <class \'TypeError\'>: query_chips() got an unexpected keyword argument \'__jobid__\'
  [!on_engine_request] jobid = \'3a768a89-c0e6-49d6-aca1-0bc10abdbd40\'
  </!!! EXCEPTION !!!>
  ```
  
  Change `wbia/web/job_engine.py` `on_engine_request` to not add
  `__jobid__` to the keyword arguments if this error is returned.  (I'm
  not sure why `__jobid__` is added at all.)
  
  This fixes the exception and allows the job to complete.

- Remove deprecated arguments from add_images_json test

  ```
  DOCTEST TRACEBACK
  Traceback (most recent call last):
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 556, in run
      exec(code, test_globals)
    File "<doctest:/wbia/wildbook-ia/wbia/web/apis_json.py::add_images_json:0>", line rel: 34, abs: 389, in <module>
      >>> gid_list = wbia.web.apis_json.add_images_json(web_instance, **_payload)
    File "/wbia/wildbook-ia/wbia/web/apis_json.py", line 479, in add_images_json
      % (bad_list,)
  ValueError: This API signature has changed, the following parameters have been deprecated: ['image_uuid_list', 'image_width_list', 'image_height_list'].  Please remove them and try again.
  DOCTEST REPRODUCTION
  CommandLine:
      pytest /wbia/wildbook-ia/wbia/web/apis_json.py::add_images_json:0
  /wbia/wildbook-ia/wbia/web/apis_json.py:389: ValueError
  ============================================================= short test summary info =============================================================
  FAILED wbia/web/apis_json.py::add_images_json:0
  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ======================================= 1 failed, 647 passed, 592 skipped, 5 warnings in 1337.95s (0:22:17) =======================================
  ```

- Skip wbia/web/apis_json.py::add_images_json:0 test

  ```
  boto.exception.NoAuthHandlerFound: No handler was ready to authenticate. 1 handlers were checked.
  ```

- Fix assertion error message in web/apis_query.py::query_chips

  When `qreq_` is `None` and `qaid_list` or `daid_list` is `None`, the
  assertion error message is:
  
  ```
  AssertionError: do not specify daids and qreq
  ```
  
  but actually the user needs to define `qaid_list` and `daid_list`
  because `qreq_` is not defined.

- Fix web/apis_query.py::query_chips_simple_dict:1 test

  The first traceback was:
  
  ```
  DOCTEST TRACEBACK
  Traceback (most recent call last):
    File "/virtualenv/env3/lib/python3.6/site-packages/xdoctest/doctest_example.py", line 556, in run
      exec(code, test_globals)
    File "<doctest:/wbia/wildbook-ia/wbia/web/apis_query.py::query_chips_simple_dict:1>", line rel: 9, abs: 102, in <module>
      >>> web_port = ibs.get_web_port_via_scan()
  NameError: name 'ibs' is not defined
  ```
  
  I changed the test to use `opendb_bg_web` instead of `opendb_in_background` to
  get rid of the code to wait for the server to be up.  Also use
  `send_wbia_request` instead of `requests`.
  
  The second error:
  
  ```
  <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">                                                                                            <title>404 Not Found</title>
  <h1>Not Found</h1>
  <p>The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.</p>
  ```
  
  The url needs to be changed to `/api/query/chip/dict/simple/` from
  `/api/query/chip/simple/dict/`.
  
  The third traceback:
  
  ```
  Traceback (most recent call last):
    File "/wbia/wildbook-ia/wbia/control/controller_inject.py", line 590, in translate_wbia_webcall
      output = func(ibs=ibs, **kwargs)
    File "/wbia/wildbook-ia/wbia/web/apis_query.py", line 109, in query_chips_simple_dict
      return ibs.query_chips(*args, **kwargs)
    File "/wbia/wildbook-ia/wbia/web/apis_query.py", line 1290, in query_chips
      assert daid_list is not None, 'do not specify daids and qreq'
  AssertionError: Need to specify daids
  ```
  
  Add `daid_list=[1, 2, 3]` to the argument to get the test to work.

- Skip wbia/web/apis_query.py::query_chips_simple_dict:1 test

  When running the `query_chips_simple_dict` tests together, the second
  one hangs:
  
  ```
  pytest -x --web-tests wbia/web/apis_query.py::query_chips_simple_dict:{0,1} -s
  ```
  
  So just skip it for now.

  After a lot of time debugging, the problem lies in `wbia/algo/hots/pipeline.py`:
  
  ```
  def cachemiss_nn_compute_fn(
  ...
          qvec_iter = ut.ProgressIter(qvecs_list, lbl=NN_LBL, prog_hook=prog_hook, **PROGKW)
          idx_dist_list = [
              qreq_.indexer.knn(qfx2_vec, num_neighbors)
              for qfx2_vec, num_neighbors in zip(qvec_iter, num_neighbors_list)
          ]
  ...
  ```
  
  But I haven't looked further.  I'm going to leave it for now.
