### PR TITLE
Implement Metadata attribution on the SQL Controller

### DIFF
--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -424,6 +424,14 @@ class SQLDatabaseController(object):
                 """Because keys are `<table-name>_<name>`"""
                 return '_'.join([self.table_name, name])
 
+            def update(self, **kwargs):
+                """Update or insert the value into the metadata table with the given keyword arguments of metadata field names"""
+                for keyword, value in kwargs.items():
+                    if keyword not in METADATA_TABLE_COLUMN_NAMES:
+                        # ignore unknown keywords
+                        continue
+                    setattr(self, keyword, value)
+
             def __getattr__(self, name):
                 # Query the database for the value represented as name
                 key = '_'.join([self.table_name, name])

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -1891,14 +1891,7 @@ class SQLDatabaseController(object):
         operation = self._make_add_table_sqlstr(tablename, coldef_list, **metadata_keyval)
         self.executeone(operation, [], verbose=False)
 
-        # Handle table metdata
-        for suffix in METADATA_TABLE_COLUMN_NAMES:
-            if suffix in metadata_keyval and metadata_keyval[suffix] is not None:
-                val = metadata_keyval[suffix]
-                if suffix in ['docstr']:
-                    self.set_metadata_val(tablename + '_' + suffix, val)
-                else:
-                    self.set_metadata_val(tablename + '_' + suffix, repr(val))
+        self.metadata[tablename].update(**metadata_keyval)
         if self._tablenames is not None:
             self._tablenames.add(tablename)
 

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -44,16 +44,20 @@ SQLColumnRichInfo = collections.namedtuple(
 #       Use this definition as the authority because it's within the context of its use.
 METADATA_TABLE_NAME = 'metadata'
 # Defines the columns used within the metadata table.
-METADATA_TABLE_COLUMN_NAMES = (
-    'dependson',
-    'docstr',
-    'relates',
-    'shortname',
-    'superkeys',
-    'extern_tables',
-    'dependsmap',
-    'primary_superkey',
-)
+METADATA_TABLE_COLUMNS = {
+    # Dictionary of metadata column names pair with:
+    #  - is_coded_data: bool showing if the value is a data type (True) or string (False)
+    # <column-name>: <info-dict>
+    'dependson': dict(is_coded_data=True),
+    'docstr': dict(is_coded_data=False),
+    'relates': dict(is_coded_data=True),
+    'shortname': dict(is_coded_data=True),
+    'superkeys': dict(is_coded_data=True),
+    'extern_tables': dict(is_coded_data=True),
+    'dependsmap': dict(is_coded_data=True),
+    'primary_superkey': dict(is_coded_data=True),
+}
+METADATA_TABLE_COLUMN_NAMES = list(METADATA_TABLE_COLUMNS.keys())
 
 
 def _unpacker(results_):
@@ -375,6 +379,141 @@ class SQLDatabaseController(object):
     Interface to an SQL database
     """
 
+    class Metadata:
+        """Metadata is an attribute of the ``SQLDatabaseController`` that
+        facilitates easy usages by internal and exteral users.
+        Each metadata attributes represents a table (i.e. an instance of ``TableMetadata``).
+        Each ``TableMetadata`` instance has metadata names as attributes.
+        The ``TableMetadata`` can also be adapated to a dictionary for compatability.
+
+        The the ``database`` attribute is a special case that results
+        in a ``DatabaseMetadata`` instance rather than ``TableMetadata``.
+        This primarily give access to the version and initial UUID,
+        respectively as ``database.version`` and ``database.init_uuid``.
+
+        Args:
+            ctrlr (SQLDatabaseController): parent controller object
+
+        """
+
+        class DatabaseMetadata:
+            """Special metadata for database information"""
+
+            version = None
+            init_uuid = None
+
+            def __init__(self, ctrlr):
+                # Query for the database metadata.
+                self.version = ctrlr.executeone(
+                    f'SELECT metadata_value FROM {METADATA_TABLE_NAME} WHERE metadata_key = ?',
+                    ('database_version',),
+                )[0]
+                self.init_uuid = ctrlr.executeone(
+                    f'SELECT metadata_value FROM {METADATA_TABLE_NAME} WHERE metadata_key = ?',
+                    ('database_init_uuid',),
+                )[0]
+
+        class TableMetadata:
+            """Metadata on a particular SQL table"""
+
+            def __init__(self, ctrlr, table_name):
+                super().__setattr__('ctrlr', ctrlr)
+                super().__setattr__('table_name', table_name)
+
+            def _get_key_name(self, name):
+                """Because keys are `<table-name>_<name>`"""
+                return '_'.join([self.table_name, name])
+
+            def __getattr__(self, name):
+                # Query the database for the value represented as name
+                key = '_'.join([self.table_name, name])
+                statement = (
+                    'SELECT metadata_value '
+                    f'FROM {METADATA_TABLE_NAME} '
+                    'WHERE metadata_key = ?'
+                )
+                try:
+                    value = self.ctrlr.executeone(statement, (key,))[0]
+                except IndexError:
+                    # No value for the requested metadata_key
+                    return None
+                if METADATA_TABLE_COLUMNS[name]['is_coded_data']:
+                    value = eval(value)
+                return value
+
+            def __getattribute__(self, name):
+                return super().__getattribute__(name)
+
+            def __setattr__(self, name, value):
+                try:
+                    info = METADATA_TABLE_COLUMNS[name]
+                except KeyError:
+                    # This prevents setting of any attributes outside of the known names
+                    raise AttributeError
+
+                # Delete the record if given None
+                if value is None:
+                    return self.__delattr__(name)
+
+                if info['is_coded_data']:
+                    # Treat the data as code.
+                    value = repr(value)
+                key = self._get_key_name(name)
+
+                # Insert or update the record
+                # FIXME postgresql (4-Aug-12020) 'insert or replace' is not valid for postgresql
+                statement = (
+                    f'INSERT OR REPLACE INTO {METADATA_TABLE_NAME} '
+                    f'(metadata_key, metadata_value) VALUES (?, ?)'
+                )
+                params = (
+                    key,
+                    value,
+                )
+                self.ctrlr.executeone(statement, params)
+
+            def __delattr__(self, name):
+                if name not in METADATA_TABLE_COLUMN_NAMES:
+                    # This prevents deleting of any attributes outside of the known names
+                    raise AttributeError
+
+                # Insert or update the record
+                statement = f'DELETE FROM {METADATA_TABLE_NAME} where metadata_key = ?'
+                params = (self._get_key_name(name),)
+                self.ctrlr.executeone(statement, params)
+
+            def __dir__(self):
+                return METADATA_TABLE_COLUMN_NAMES
+
+        def __init__(self, ctrlr):
+            super().__setattr__('ctrlr', ctrlr)
+
+        def __getattr__(self, name):
+            # If the table exists pass back a ``TableMetadata`` instance
+            if name == 'database':
+                value = self.DatabaseMetadata(self.ctrlr)
+            else:
+                if name not in self.ctrlr.get_table_names():
+                    raise ValueError(f'not a valid tablename: {name}')
+                value = self.TableMetadata(self.ctrlr, name)
+            return value
+
+        def __getattribute__(self, name):
+            return super().__getattribute__(name)
+
+        def __setattr__(self, name, value):
+            # This is inaccessible since any changes
+            # to a TableMetadata instance would make on-demand mutations.
+            raise NotImplementedError
+
+        def __delattr__(self, name):
+            # no-op
+            pass
+
+        def __dir__(self):
+            # List all available tables, plus 'database'
+            pass
+
     @profile
     def __init__(
         self,
@@ -427,6 +566,7 @@ class SQLDatabaseController(object):
         self.timeout = timeout
         self._tablenames = None
         self.readonly = readonly
+        self.metadata = self.Metadata(self)
 
         # Get SQL file path
         if fpath is None:
@@ -482,6 +622,7 @@ class SQLDatabaseController(object):
         self = cls.__new__(cls)
         self.uri = uri
         self.timeout = timeout
+        self.metadata = self.Metadata(self)
 
         self._tablenames = None
         # FIXME (31-Jul-12020) rename to private attribute

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -11,7 +11,7 @@ import os
 import parse
 import re
 import threading
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from functools import partial
 from io import StringIO
 from os.path import join, exists, dirname, basename
@@ -397,24 +397,73 @@ class SQLDatabaseController(object):
 
         """
 
-        class DatabaseMetadata:
+        class DatabaseMetadata(MutableMapping):
             """Special metadata for database information"""
 
-            version = None
-            init_uuid = None
+            __fields = (
+                'version',
+                'init_uuid',
+            )
 
             def __init__(self, ctrlr):
-                # Query for the database metadata.
-                self.version = ctrlr.executeone(
+                self.ctrlr = ctrlr
+
+            @property
+            def version(self):
+                return self.ctrlr.executeone(
                     f'SELECT metadata_value FROM {METADATA_TABLE_NAME} WHERE metadata_key = ?',
                     ('database_version',),
                 )[0]
-                self.init_uuid = ctrlr.executeone(
+
+            @version.setter
+            def version(self, value):
+                if not value:
+                    raise ValueError(value)
+                return self.ctrlr.executeone(
+                    f'INSERT OR REPLACE INTO {METADATA_TABLE_NAME} (metadata_key, metadata_value) VALUES (?, ?)',
+                    ('database_version', value,),
+                )[0]
+
+            @property
+            def init_uuid(self):
+                return self.ctrlr.executeone(
                     f'SELECT metadata_value FROM {METADATA_TABLE_NAME} WHERE metadata_key = ?',
                     ('database_init_uuid',),
                 )[0]
 
-        class TableMetadata:
+            @init_uuid.setter
+            def init_uuid(self, value):
+                if not value:
+                    raise ValueError(value)
+                return self.ctrlr.executeone(
+                    f'INSERT OR REPLACE INTO {METADATA_TABLE_NAME} (metadata_key, metadata_value) VALUES (?, ?)',
+                    ('database_init_uuid', value,),
+                )[0]
+
+            # collections.abc.MutableMapping abstract methods
+
+            def __getitem__(self, key):
+                try:
+                    return getattr(self, key)
+                except AttributeError as exc:
+                    raise KeyError(*exc.args)
+
+            def __setitem__(self, key, value):
+                if key not in self.__fields:
+                    raise AttributeError(key)
+                setattr(self, key, value)
+
+            def __delitem__(self, key):
+                raise RuntimeError(f"'{key}' cannot be deleted")
+
+            def __iter__(self):
+                for name in self.__fields:
+                    yield name
+
+            def __len__(self):
+                return len(self.__fields)
+
+        class TableMetadata(MutableMapping):
             """Metadata on a particular SQL table"""
 
             def __init__(self, ctrlr, table_name):
@@ -493,6 +542,33 @@ class SQLDatabaseController(object):
 
             def __dir__(self):
                 return METADATA_TABLE_COLUMN_NAMES
+
+            # collections.abc.MutableMapping abstract methods
+
+            def __getitem__(self, key):
+                try:
+                    return self.__getattr__(key)
+                except AttributeError as exc:
+                    raise KeyError(*exc.args)
+
+            def __setitem__(self, key, value):
+                try:
+                    setattr(self, key, value)
+                except AttributeError as exc:
+                    raise KeyError(*exc.args)
+
+            def __delitem__(self, key):
+                try:
+                    setattr(self, key, None)
+                except AttributeError as exc:
+                    raise KeyError(*exc.args)
+
+            def __iter__(self):
+                for name in METADATA_TABLE_COLUMN_NAMES:
+                    yield name
+
+            def __len__(self):
+                return len(METADATA_TABLE_COLUMN_NAMES)
 
         def __init__(self, ctrlr):
             super().__setattr__('ctrlr', ctrlr)

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -11,6 +11,7 @@ import os
 import parse
 import re
 import threading
+from collections.abc import Mapping
 from functools import partial
 from io import StringIO
 from os.path import join, exists, dirname, basename
@@ -379,7 +380,7 @@ class SQLDatabaseController(object):
     Interface to an SQL database
     """
 
-    class Metadata:
+    class Metadata(Mapping):
         """Metadata is an attribute of the ``SQLDatabaseController`` that
         facilitates easy usages by internal and exteral users.
         Each metadata attributes represents a table (i.e. an instance of ``TableMetadata``).
@@ -502,7 +503,7 @@ class SQLDatabaseController(object):
                 value = self.DatabaseMetadata(self.ctrlr)
             else:
                 if name not in self.ctrlr.get_table_names():
-                    raise ValueError(f'not a valid tablename: {name}')
+                    raise AttributeError(f'not a valid tablename: {name}')
                 value = self.TableMetadata(self.ctrlr, name)
             return value
 
@@ -520,7 +521,23 @@ class SQLDatabaseController(object):
 
         def __dir__(self):
             # List all available tables, plus 'database'
-            pass
+            raise NotImplementedError
+
+        # collections.abc.Mapping abstract methods
+
+        def __getitem__(self, key):
+            try:
+                return self.__getattr__(key)
+            except AttributeError as exc:
+                raise KeyError(*exc.args)
+
+        def __iter__(self):
+            for name in self.ctrlr.get_table_names():
+                yield name
+            yield 'database'
+
+        def __len__(self):
+            return len(self.ctrlr.get_table_names()) + 1  # for 'database'
 
     @profile
     def __init__(

--- a/wbia/tests/dtool/test_sql_control.py
+++ b/wbia/tests/dtool/test_sql_control.py
@@ -162,3 +162,16 @@ class TestMetadataProperty:
         # Check for updates
         for k in targets:
             assert getattr(self.ctrlr.metadata.foo, k) == targets[k]
+
+    # ###
+    # Test item access methods proxy to attribute access methods
+    # ###
+
+    def test_getitem(self):
+        # Check getting of a value by key
+        assert self.ctrlr.metadata['foo'].table_name == 'foo'
+
+    def test_getitem_for_unknown_table(self):
+        # Check getting the metdata for an unknown table
+        with pytest.raises(KeyError):
+            assert self.ctrlr.metadata['bar']

--- a/wbia/tests/dtool/test_sql_control.py
+++ b/wbia/tests/dtool/test_sql_control.py
@@ -65,6 +65,10 @@ class TestMetadataProperty:
     def monkey_get_table_names(self, *args, **kwargs):
         return ['foo', 'metadata']
 
+    # ###
+    # Test attribute access methods
+    # ###
+
     def test_getter(self):
         # Check getting of a value by key
         assert self.data['foo_relates'] == self.ctrlr.metadata.foo.relates
@@ -141,3 +145,20 @@ class TestMetadataProperty:
         assert self.ctrlr.metadata.database.version == '0.0.0'
         # Check the database init_uuid, verified via evaluating it
         assert uuid.UUID(self.ctrlr.metadata.database.init_uuid)
+
+    # ###
+    # Test batch manipulation methods
+    # ###
+
+    def test_update(self):
+        targets = {
+            'superkeys': [('k',), ('x', 'y',)],
+            'dependson': ['baz'],
+            'docstr': 'hahaha',
+        }
+        # Updating from dict
+        self.ctrlr.metadata.foo.update(**targets)
+
+        # Check for updates
+        for k in targets:
+            assert getattr(self.ctrlr.metadata.foo, k) == targets[k]


### PR DESCRIPTION
## Description

IMO this adds a better API for accessing table and database metadata. The metadata will be available as attributes (e.g. `controller.metadata.chips.relates`) that have getters, setters and deletters. See the new Metadata class' docstr for more details.

Previous usage would be something like:
```python
controller.get_metadata_val(table_name + '_' + key)
controller.set_metadata_val(table_name + '_' + key, value)
```
The usage would now become *any* of the following:
```python
controller.metadata[table_name][key]
getattr(getattr(controller.metadata, table_name), key)
getattr(controller.metadata[table_name], key)

controller.metadata[table_name][key] = value
```
Or, if you know specifically what you are after:
```python
controller.metadata.database.version
controller.metadata.foo_table.docstr

controller.metadata.database.version = '1.1.1'
controller.metadata.chips.docstr = "chips and dip"
```

The motivation for this change is to remove the unnecessary looping over metadata entities and key building operation in several of the methods. All that redundant behavior gets collapsed into these metadata classes.

Note, I really appreciate the original author's intention to put metadata about the tables in the database itself. And thus, I'm trying my best to preserve that information and make it easily accessible for use in higher level APIs.

## Direction

Note, I've not touched the `*_metadata_val` methods in this set of changes. They require a bit more work to preserve their existing behavior. I'll be _replacing their internal logic and deprecating them_ in a followup changeset.

One now known flaw in the naming of the metadata keys is the use of `_` as both a naming separator and the table name to key separator (e.g. `web_src_docstr` or `database_init_uuid`). It'd have been better to use something like `.` (e.g. `web_src.docstr` or `database.init_uuid`). The reason I mention this is because it's what I believe has locked the code into the need to redundantly iterate over the keys to build the metadata_key. But I digress... Long story short is that I'll make it work in a followup changeset.