### PR TITLE
Deprecate tablenames methods in favor of table_names property 

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -5,6 +5,7 @@ colorama>=0.3.2
 dateutils>=0.6.6
 
 delorean
+deprecated
 docker
 flask>=0.10.1
 

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -2068,6 +2068,9 @@ class SQLDatabaseController(object):
         line_list.append('')
         return '\n'.join(line_list)
 
+    # FIXME (6-Aug-12020) 'constraint' is not within METADATA_TABLE_COLUMN_NAMES
+    #       Consider deprecating or adding the functionality.
+    #       SQL introspection should maybe be used instead
     def get_table_constraints(self, tablename):
         """
         TODO: use coldef_list with table_autogen_dict instead


### PR DESCRIPTION
This is more of a naming change than anything, but it also helps to
guarantees the use of `_tablenames` is no longer used outside
of this class.

Invalidation of the cached table names is now done implicitly through
the use of `_is_table_names_stale`. This allows known manipulaters of
the table names to invalidate the cache rather than external api users
of the tables names data to invalidate it on invocation.