### PR TITLE
Add pytest option to disable the set_up_db fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,3 +8,11 @@ def pytest_addoption(parser):
     parser.addoption('--tomcat', action='store_true')
     parser.addoption('--web-tests', action='store_true')
     parser.addoption('--weird', action='store_true')
+    parser.addoption(
+        '--disable-refresh-db',
+        action='store_true',
+        help=(
+            "disables the set_up_db fixture from rebuilding the db, "
+            "instead it will reuse the previous test run's db"
+        ),
+    )

--- a/wbia/conftest.py
+++ b/wbia/conftest.py
@@ -32,12 +32,17 @@ def enable_wildbook_signal():
 
 @pytest.fixture(scope='session', autouse=True)
 @pytest.mark.usefixtures('enable_wildbook_signal')
-def set_up_db():
+def set_up_db(request):
     """
     Sets up the testing databases.
     This fixture is set to run automatically any any test run of wbia.
 
     """
+    # If selected, disable running the main logic of this fixture
+    if request.config.getoption("--disable-refresh-db", False):
+        # Assume the user knows what they are requesting
+        return  # bale out
+
     # Delete DBs, if they exist
     # FIXME (16-Jul-12020) this fixture does not cleanup after itself to preserve exiting usage behavior
     for dbname in TEST_DBNAMES_MAP.values():


### PR DESCRIPTION
I've added this because the setting up of the db is slightly time
intensive. Because the data can be used between tests, this option
allows for the developers (us) to manually disable the fixture between
test runs.