### PR TITLE
Silence UserWarnings on import of wbia

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -7,6 +7,8 @@ dateutils>=0.6.6
 delorean
 docker
 flask>=0.10.1
+flask-cas
+flask-cors
 
 futures_actors
 ipython>=5.0.0


### PR DESCRIPTION
This silences the following user warnings when doing `import wbia`.
```
.../wbia/control/controller_inject.py:58: UserWarning: Missing flask.ext.cors
  warnings.warn('Missing flask.ext.cors')
.../wbia/control/controller_inject.py:77: UserWarning: Missing flask.ext.cas.
To install try pip install git+https://github.com/cameronbwhite/Flask-CAS.git
  warnings.warn(msg)
```

Just trying to cut out some of the invalid chatter, so I know when
something important is actually happening.