### PR TITLE
Rename runtime image to wildme/wildbook-ia

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,8 +17,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        if: github.event_name == 'schedule'
         with:
           ref: develop
+      - uses: actions/checkout@v2
+        if: github.event_name != 'schedule'
 
       # Build containers
       - name: Build containers

--- a/devops/build.sh
+++ b/devops/build.sh
@@ -16,4 +16,4 @@ docker build -t wildme/wbia:latest .
 
 cd ../
 # Build the runtime container
-docker build -t wildbook/wildbook-ia:latest .
+docker build -t wildme/wildbook-ia:latest .


### PR DESCRIPTION
- Rename runtime image to wildme/wildbook-ia

  It was named `wildbook/wildbook-ia`, different from all the other images
  named `wildme/*`.  It causes the nightly build to fail because
  `devops/publish.py` has a hardcoded prefix `wildme/`.  So just rename
  the runtime image to `wildme/wildbook-ia`.

- Checkout develop branch or PR branch in nightly workflow

  Use the develop branch if it's the scheduled nightly workflow but use
  the PR branch if any related files changed.
