### PR TITLE
Change base image to use cuda:10.0-cudnn7-devel-ubuntu18.04

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Notify status in Slack
       - name: Slack Notification
-        if: failure()
+        if: ${{ failure() && github.event_name == 'schedule' }}
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_CHANNEL: ia-development

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,11 @@ jobs:
   devops:
     name: DevOps container image build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        images:
+          - wildbook-ia
+          - wbia-base wbia-dependencies wbia-provision wbia
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +30,7 @@ jobs:
 
       # Build containers
       - name: Build containers
-        run: bash devops/build.sh
+        run: bash devops/build.sh ${{ matrix.images }}
 
       # Log into container registries
       - name: Log into Docker Hub
@@ -35,10 +40,10 @@ jobs:
 
       # Push containers out to container registries
       - name: Push to GitHub Packages
-        run: bash devops/publish.sh -t nightly -r docker.pkg.github.com
+        run: bash devops/publish.sh -t nightly -r docker.pkg.github.com ${{ matrix.images }}
       - name: Push to Docker Hub
         if: github.event_name == 'schedule'
-        run: bash devops/publish.sh -t nightly
+        run: bash devops/publish.sh -t nightly ${{ matrix.images }}
 
       # Notify status in Slack
       - name: Slack Notification

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # cnmem build stage
 #
 
-FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04 AS cnmem-build
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS cnmem-build
 # Install system dependencies
 RUN set -x \
     && apt-get update \
@@ -29,7 +29,7 @@ RUN git clone https://github.com/NVIDIA/cnmem.git /tmp/cnmem \
 # runtime build stage
 #
 
-FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04 AS runtime
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 AS runtime
 
 MAINTAINER Wild Me <dev@wildme.org>
 

--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04 as org.wildme.wbia.base
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04 as org.wildme.wbia.base
 
 MAINTAINER Wild Me <dev@wildme.org>
 

--- a/devops/build.sh
+++ b/devops/build.sh
@@ -9,11 +9,22 @@ export ROOT_LOC="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 cd ${ROOT_LOC}
 
 # Build the images in dependence order
-docker build -t wildme/wbia-base:latest base
-docker build -t wildme/wbia-dependencies:latest dependencies
-docker build -t wildme/wbia-provision:latest provision
-docker build -t wildme/wbia:latest .
-
-cd ../
-# Build the runtime container
-docker build -t wildme/wildbook-ia:latest .
+while [ $# -ge 1 ]; do
+    if [ "$1" == "wbia-base" ]; then
+        docker build -t wildme/wbia-base:latest base
+    elif [ "$1" == "wbia-dependencies" ]; then
+        docker build -t wildme/wbia-dependencies:latest dependencies
+    elif [ "$1" == "wbia-provision" ]; then
+        docker build -t wildme/wbia-provision:latest provision
+    elif [ "$1" == "wbia" ]; then
+        docker build -t wildme/wbia:latest .
+    elif [ "$1" == "wildbook-ia" ]; then
+        cd ../
+        # Build the runtime container
+        docker build -t wildme/wildbook-ia:latest .
+    else
+        echo "Image $1 not found"
+        exit 1
+    fi
+    shift
+done

--- a/devops/publish.sh
+++ b/devops/publish.sh
@@ -3,7 +3,7 @@
 set -e
 
 usage () {
-    echo "Usage: $0 [-t <tag>] [-r <registry-url>]";
+    echo "Usage: $0 [-t <tag>] [-r <registry-url>] [<image> ...]";
 }
 
 # Parse commandline options
@@ -14,10 +14,12 @@ while getopts ":t:r:" option; do
         \? ) usage; exit 1;;
     esac
 done
+shift $((OPTIND - 1))
 
 # Assign variables
 TAG=${TAG:-latest}
 REGISTRY=${REGISTRY:-}
+IMAGES=${@:-wbia-base wbia-dependencies wbia-provision wbia wildbook-ia}
 # Set the image prefix
 if [ -n "$REGISTRY" ]; then
     IMG_PREFIX="${REGISTRY}/wildbookorg/wildbook-ia/"
@@ -26,9 +28,10 @@ else
 fi
 
 # Tag built images from `build.sh`, which tags as `latest`
-for IMG in wbia-base wbia-dependencies wbia-provision wbia wildbook-ia; do
+for IMG in $IMAGES; do
     echo "Tagging wildme/${IMG}:latest --> ${IMG_PREFIX}${IMG}:${TAG}"
     docker tag wildme/${IMG}:latest ${IMG_PREFIX}${IMG}:${TAG}
     echo "Pushing ${IMG_PREFIX}${IMG}:${TAG}"
     docker push ${IMG_PREFIX}${IMG}:${TAG}
+    docker rmi wildme/${IMG}:latest
 done


### PR DESCRIPTION
We were using `cuda:9.2-cudnn7-devel-ubuntu18.04`.

The latest version of cuda is 10.2 but the latest Tensorflow supports up
to CUDA 10.1 update 2:
https://github.com/tensorflow/tensorflow/issues/40227#issuecomment-653628234

Jason Parham: We are having to downgrade our tensorflow install and it needs 10.0