### PR TITLE
Add wbia-cnn to runtime requirements

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,10 +32,14 @@ jobs:
           # Using manylinux2014 because running the test command requires
           # pyqt5 which only has wheels for manylinux2014
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64
-          CIBW_TEST_COMMAND: python -c "import wbia; from wbia.__main__ import smoke_test; smoke_test()"
         run: |
           python -m pip install cibuildwheel==1.4.2
           python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Run smoke test
+        run: |
+          python -m pip install ./wheelhouse/*.whl
+          python -c "import wbia; from wbia.__main__ import smoke_test; smoke_test()"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -9,7 +9,6 @@ RUN git clone https://github.com/opencv/opencv.git                        /wbia/
  && git clone https://github.com/opencv/opencv_contrib.git                /wbia/opencv_contrib \
  && git clone https://github.com/Theano/libgpuarray.git                   /wbia/libgpuarray \
  && git clone https://github.com/Theano/Theano.git                        /wbia/Theano \
- && git clone https://github.com/Lasagne/Lasagne.git                      /wbia/Lasagne \
  && git clone https://github.com/networkx/networkx.git                    /wbia/networkx
 
 # Install basic Python3 dependencies (and ones that were missing in IBEIS install)
@@ -130,8 +129,6 @@ RUN /virtualenv/env3/bin/pip install git+https://github.com/aleju/imgaug \
 
 # Install Python dependencies
 RUN cd /wbia/Theano \
- && /virtualenv/env3/bin/pip install -e . \
- && cd /wbia/Lasagne \
  && /virtualenv/env3/bin/pip install -e . \
  && cd /wbia/networkx \
  && /virtualenv/env3/bin/pip install -e .

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -20,7 +20,6 @@ RUN git clone --branch develop https://github.com/WildbookOrg/wbia-tpl-brambox  
  && git clone --branch master https://github.com/WildbookOrg/wbia-plugin-kaggle7        /wbia/wbia-plugin-kaggle7 \
  && git clone --branch master https://github.com/WildbookOrg/wbia-plugin-2d-orientation /wbia/wbia-plugin-2d-orientation \
  && git clone --branch develop https://github.com/WildbookOrg/wildbook-ia               /wbia/wildbook-ia \
- && git clone --branch develop https://github.com/WildbookOrg/wbia-plugin-cnn           /wbia/wbia-plugin-cnn \
  && git clone --branch master https://github.com/WildbookOrg/wbia-tpl-lightnet          /wbia/lightnet \
  && git clone --branch develop https://github.com/WildbookOrg/wbia-tpl-pydarknet        /wbia/pydarknet \
  && git clone --branch develop https://github.com/WildbookOrg/wbia-tpl-pyrf             /wbia/pyrf \
@@ -88,9 +87,6 @@ RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && /bin/bash run_developer_setup.sh'
 
 # Install Python repositories
-RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
- && cd /wbia/wbia-plugin-cnn \
- && pip install -e .'
 RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/hesaff \
  && pip install -e .'

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -43,6 +43,7 @@ torchvision
 tornado>=4.2.1
 tqdm
 ubelt >= 0.8.7
+wbia-cnn>=3.0.2
 wbia-pydarknet >= 3.0.1
 wbia-pyflann >= 3.1.0
 wbia-pyhesaff >= 3.0.2


### PR DESCRIPTION
- Add wbia-cnn to runtime requirements

  `wbia-cnn` adds `generate_species_background_mask` to `IBEISController`
  which seems to be central to a lot of the functionality in wildbook-ia.
  
  We have 13 tests that don't work without `wbia-cnn`.  It seems that
  `wbia-cnn` isn't like other plugins and should be installed as a runtime
  requirement.
  
  `wbia-cnn` requires `Lasagne` but the version on pypi is too old so we
  have embedded it in `wbia-cnn`.

- Install wbia-cnn from pypi in provision dockerfile

  We have uploaded wbia-cnn to pypi and we should use that instead.
  
  Also remove Lasagne from dependencies dockerfile.

- Run smoke test outside of cibuildwheel in github action

  When running smoke test inside cibuildwheel, there's some compilation error.
  This can be seen by doing:
  
  ```
  docker run --rm -ti quay.io/pypa/manylinux2014_x86_64:latest /bin/bash
  ```
  
  ```
  export PATH=/opt/python/cp36-cp36m/bin:$PATH
  git clone -b karenc/pypi-wbia-cnn https://github.com/WildbookOrg/wildbook-ia.git
  pip wheel ./wildbook-ia -w /tmp/built_wheel --no-deps
  pip install /tmp/built_wheel/wildbook_ia-3.0.3.dev275-py3-none-any.whl
  ```
  
  ```
  [root@6a4922a74c73 built_wheel]# python -c 'import wbia; from wbia.__main__ import smoke_test'
  VTOOL BACKEND FOR pyflann = <module 'pyflann' from '/opt/python/cp36-cp36m/lib/python3.6/site-packages/pyflann/__init__.py'>
  VTOOL BACKEND FOR FLANN_CLS = <class 'pyflann.index.FLANN'>
  [pydarknet] CPU fallback for: pydarknet_cuda
  Local docker client is not available
  
  You can find the C code in this temporary file: /tmp/theano_compilation_error_a7ksvfng
  library inux/9/ld: is not found.
  library python3.6m is not found.
  Check if package python-dev 3.6 or python-devel 3.6 is installed.
  
  +------
  
  <!!! EXCEPTION !!!>
  Traceback (most recent call last):
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/theano/gof/lazylinker_c.py", line 81, in <module>
      actual_version, force_compile, _need_reload))
  ImportError: Version check of the existing lazylinker compiled file. Looking for version 0.211, but found None. Extra debug information: force_compile=False, _need_reload=True
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/theano/gof/lazylinker_c.py", line 105, in <module>
      actual_version, force_compile, _need_reload))
  ImportError: Version check of the existing lazylinker compiled file. Looking for version 0.211, but found None. Extra debug information: force_compile=False, _need_reload=True
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/__init__.py", line 53, in <module>
      from wbia import other
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/other/__init__.py", line 7, in <module>
      from wbia.other import detectgrave
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/other/detectgrave.py", line 18, in <module>
      from wbia.control import controller_inject
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/control/__init__.py", line 12, in <module>
      from wbia.control import IBEISControl
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/control/IBEISControl.py", line 168, in <module>
      ub.import_module_from_name(modname)
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/ubelt/util_import.py", line 260, in import_module_from_name
      module = importlib.import_module(modname)
    ...
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/theano/gof/cmodule.py", line 2411, in compile_str
      (status, compile_stderr.replace('\n', '. ')))
  Exception: Compilation failed (return status=1): /opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: cannot find -lpython3.6m. collect2: error: ld returned 1 exit status.
  
  ...
  
  During handling of the above exception, another exception occurred:
  
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/__init__.py", line 53, in <module>
      from wbia import other
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/other/__init__.py", line 7, in <module>
      from wbia.other import detectgrave
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/other/detectgrave.py", line 18, in <module>
      from wbia.control import controller_inject
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/control/__init__.py", line 12, in <module>
      from wbia.control import IBEISControl
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/wbia/control/IBEISControl.py", line 168, in <module>
      ub.import_module_from_name(modname)
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/ubelt/util_import.py", line 260, in import_module_from_name
      module = importlib.import_module(modname)
    ...
    File "/opt/python/cp36-cp36m/lib/python3.6/site-packages/theano/gof/cmodule.py", line 2411, in compile_str
      (status, compile_stderr.replace('\n', '. ')))
  Exception: Compilation failed (return status=1): /opt/rh/devtoolset-9/root/usr/libexec/gcc/x86_64-redhat-linux/9/ld: cannot find -lpython3.6m. collect2: error: ld returned 1 exit status.
  ```
  
  This doesn't happen if we install the wheel outside of cibuildwheel and run the
  smoke test, so I'm doing that instead.
