### PR TITLE
SQLAlchemy user defined types

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -37,6 +37,7 @@ scikit-learn>=0.17.1
 scipy>=0.18.0
 simplejson>=3.6.5
 six>=1.10.0
+sqlalchemy
 statsmodels>=0.6.1
 
 torch

--- a/wbia/dtool/types.py
+++ b/wbia/dtool/types.py
@@ -4,11 +4,13 @@ import json
 import uuid
 
 import numpy as np
-from sqlalchemy.types import UserDefinedType
+from sqlalchemy.types import Integer as SAInteger
+from sqlalchemy.types import TypeDecorator, UserDefinedType
 
 
 __all__ = (
     'Dict',
+    'Integer',
     'List',
     'TYPE_TO_SQLTYPE',
     'UUID',
@@ -67,6 +69,13 @@ class JSONCodeableType(UserDefinedType):
 class Dict(JSONCodeableType):
     base_py_type = dict
     col_spec = 'DICT'
+
+
+class Integer(TypeDecorator):
+    impl = SAInteger
+
+    def process_bind_param(self, value, dialect):
+        return int(value)
 
 
 class List(JSONCodeableType):

--- a/wbia/dtool/types.py
+++ b/wbia/dtool/types.py
@@ -30,16 +30,21 @@ TYPE_TO_SQLTYPE = {
 }
 
 
-class Dict(UserDefinedType):
+class JSONCodeableType(UserDefinedType):
+
+    # Abstract properties
+    base_py_type = None
+    col_spec = None
+
     def get_col_spec(self, **kw):
-        return 'DICT'
+        return self.col_spec
 
     def bind_processor(self, dialect):
         def process(value):
             if value is None:
                 return value
             else:
-                if isinstance(value, dict):
+                if isinstance(value, self.base_py_type):
                     return json.dumps(value)
                 else:
                     return value
@@ -51,7 +56,7 @@ class Dict(UserDefinedType):
             if value is None:
                 return value
             else:
-                if not isinstance(value, dict):
+                if not isinstance(value, self.base_py_type):
                     return json.loads(value)
                 else:
                     return value
@@ -59,33 +64,14 @@ class Dict(UserDefinedType):
         return process
 
 
-class List(UserDefinedType):
-    def get_col_spec(self, **kw):
-        return 'LIST'
+class Dict(JSONCodeableType):
+    base_py_type = dict
+    col_spec = 'DICT'
 
-    def bind_processor(self, dialect):
-        def process(value):
-            if value is None:
-                return value
-            else:
-                if isinstance(value, list):
-                    return json.dumps(value)
-                else:
-                    return value
 
-        return process
-
-    def result_processor(self, dialect, coltype):
-        def process(value):
-            if value is None:
-                return value
-            else:
-                if not isinstance(value, list):
-                    return json.loads(value)
-                else:
-                    return value
-
-        return process
+class List(JSONCodeableType):
+    base_py_type = list
+    col_spec = 'LIST'
 
 
 class UUID(UserDefinedType):

--- a/wbia/dtool/types.py
+++ b/wbia/dtool/types.py
@@ -8,6 +8,7 @@ from sqlalchemy.types import UserDefinedType
 
 
 __all__ = (
+    'Dict',
     'List',
     'TYPE_TO_SQLTYPE',
     'UUID',
@@ -27,6 +28,35 @@ TYPE_TO_SQLTYPE = {
     dict: 'DICT',
     list: 'LIST',
 }
+
+
+class Dict(UserDefinedType):
+    def get_col_spec(self, **kw):
+        return 'DICT'
+
+    def bind_processor(self, dialect):
+        def process(value):
+            if value is None:
+                return value
+            else:
+                if isinstance(value, dict):
+                    return json.dumps(value)
+                else:
+                    return value
+
+        return process
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            if value is None:
+                return value
+            else:
+                if not isinstance(value, dict):
+                    return json.loads(value)
+                else:
+                    return value
+
+        return process
 
 
 class List(UserDefinedType):

--- a/wbia/dtool/types.py
+++ b/wbia/dtool/types.py
@@ -1,10 +1,15 @@
 # -*- coding: utf-8 -*-
 """Mapping of Python types to SQL types"""
 import uuid
+
 import numpy as np
+from sqlalchemy.types import UserDefinedType
 
 
-__all__ = 'TYPE_TO_SQLTYPE'
+__all__ = (
+    'TYPE_TO_SQLTYPE',
+    'UUID',
+)
 
 
 TYPE_TO_SQLTYPE = {
@@ -20,3 +25,33 @@ TYPE_TO_SQLTYPE = {
     dict: 'DICT',
     list: 'LIST',
 }
+
+
+class UUID(UserDefinedType):
+    def get_col_spec(self, **kw):
+        return 'UUID'
+
+    def bind_processor(self, dialect):
+        def process(value):
+            if value is None:
+                return value
+            else:
+                if not isinstance(value, uuid.UUID):
+                    return '%.32x' % uuid.UUID(value).int
+                else:
+                    # hexstring
+                    return '%.32x' % value.int
+
+        return process
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            if value is None:
+                return value
+            else:
+                if not isinstance(value, uuid.UUID):
+                    return uuid.UUID(value)
+                else:
+                    return value
+
+        return process

--- a/wbia/dtool/types.py
+++ b/wbia/dtool/types.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Mapping of Python types to SQL types"""
+import json
 import uuid
 
 import numpy as np
@@ -7,6 +8,7 @@ from sqlalchemy.types import UserDefinedType
 
 
 __all__ = (
+    'List',
     'TYPE_TO_SQLTYPE',
     'UUID',
 )
@@ -25,6 +27,35 @@ TYPE_TO_SQLTYPE = {
     dict: 'DICT',
     list: 'LIST',
 }
+
+
+class List(UserDefinedType):
+    def get_col_spec(self, **kw):
+        return 'LIST'
+
+    def bind_processor(self, dialect):
+        def process(value):
+            if value is None:
+                return value
+            else:
+                if isinstance(value, list):
+                    return json.dumps(value)
+                else:
+                    return value
+
+        return process
+
+    def result_processor(self, dialect, coltype):
+        def process(value):
+            if value is None:
+                return value
+            else:
+                if not isinstance(value, list):
+                    return json.loads(value)
+                else:
+                    return value
+
+        return process
 
 
 class UUID(UserDefinedType):

--- a/wbia/tests/dtool/test_types.py
+++ b/wbia/tests/dtool/test_types.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 import uuid
 
+import numpy as np
 import pytest
 from sqlalchemy.engine import create_engine
 from sqlalchemy.sql import text, bindparam
+from sqlalchemy.types import Float
 
 from wbia.dtool.types import Dict, List, UUID
 
@@ -55,6 +57,29 @@ def test_list(db):
     stmt = text('select x from test')
     # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-result-column-behaviors
     stmt = stmt.columns(x=List)
+    results = db.execute(stmt)
+    selected_value = results.fetchone()[0]
+    assert selected_value == insert_value
+
+
+@pytest.mark.parametrize('num_type', (np.float32, np.float64))
+def test_numpy_floats(db, num_type):
+    # Verifies that a numpy float can be translated
+
+    # Create a table that uses the type
+    db.execute(text('CREATE TABLE test(x REAL)'))
+
+    # Insert a uuid value into the table
+    insert_value = num_type(8.0000008)
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-bound-parameter-behaviors
+    stmt = text('INSERT INTO test(x) VALUES (:x)')
+    stmt = stmt.bindparams(bindparam('x', type_=Float))
+    db.execute(stmt, x=insert_value)
+
+    # Query for the value
+    stmt = text('SELECT x FROM test')
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-result-column-behaviors
+    stmt = stmt.columns(x=Float)
     results = db.execute(stmt)
     selected_value = results.fetchone()[0]
     assert selected_value == insert_value

--- a/wbia/tests/dtool/test_types.py
+++ b/wbia/tests/dtool/test_types.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import create_engine
 from sqlalchemy.sql import text, bindparam
 from sqlalchemy.types import Float
 
-from wbia.dtool.types import Dict, List, UUID
+from wbia.dtool.types import Dict, Integer, List, UUID
 
 
 @pytest.fixture(autouse=True)
@@ -80,6 +80,39 @@ def test_numpy_floats(db, num_type):
     stmt = text('SELECT x FROM test')
     # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-result-column-behaviors
     stmt = stmt.columns(x=Float)
+    results = db.execute(stmt)
+    selected_value = results.fetchone()[0]
+    assert selected_value == insert_value
+
+
+np_number_types = (
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+)
+
+
+@pytest.mark.parametrize('num_type', np_number_types)
+def test_numpy_ints(db, num_type):
+    # Create a table that uses the type
+    db.execute(text('CREATE TABLE test(x INTEGER)'))
+
+    # Insert a uuid value into the table
+    insert_value = num_type(8)
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-bound-parameter-behaviors
+    stmt = text('INSERT INTO test(x) VALUES (:x)')
+    stmt = stmt.bindparams(bindparam('x', type_=Integer))
+    db.execute(stmt, x=insert_value)
+
+    # Query for the value
+    stmt = text('SELECT x FROM test')
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-result-column-behaviors
+    stmt = stmt.columns(x=Integer)
     results = db.execute(stmt)
     selected_value = results.fetchone()[0]
     assert selected_value == insert_value

--- a/wbia/tests/dtool/test_types.py
+++ b/wbia/tests/dtool/test_types.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import uuid
+
+import pytest
+from sqlalchemy.engine import create_engine
+from sqlalchemy.sql import text, bindparam
+
+from wbia.dtool.types import UUID
+
+
+@pytest.fixture(autouse=True)
+def db():
+    engine = create_engine('sqlite:///:memory:', echo=False,)
+    with engine.connect() as conn:
+        yield conn
+
+
+def test_uuid(db):
+    # Create a table that uses the type
+    db.execute(text('CREATE TABLE test(x UUID)'))
+
+    # Insert a uuid value into the table
+    insert_value = uuid.uuid4()
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-bound-parameter-behaviors
+    stmt = text('INSERT INTO test(x) VALUES (:x)')
+    stmt = stmt.bindparams(bindparam('x', type_=UUID))
+    db.execute(stmt, x=insert_value)
+
+    # Query for the value
+    stmt = text('select x from test')
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-result-column-behaviors
+    stmt = stmt.columns(x=UUID)
+    results = db.execute(stmt)
+    selected_value = results.fetchone()[0]
+    assert selected_value == insert_value

--- a/wbia/tests/dtool/test_types.py
+++ b/wbia/tests/dtool/test_types.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy.engine import create_engine
 from sqlalchemy.sql import text, bindparam
 
-from wbia.dtool.types import UUID
+from wbia.dtool.types import List, UUID
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +13,27 @@ def db():
     engine = create_engine('sqlite:///:memory:', echo=False,)
     with engine.connect() as conn:
         yield conn
+
+
+def test_list(db):
+    # Create a table that uses the type
+    db.execute(text('CREATE TABLE test(x LIST)'))
+
+    # Insert a list of list value into the table
+    insert_value = [[1, 2, 3], [4, 5, 6]]
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-bound-parameter-behaviors
+    stmt = text('INSERT INTO test(x) VALUES (:x)')
+    stmt = stmt.bindparams(bindparam('x', type_=List))
+    db.execute(stmt, x=insert_value)
+
+
+    # Query for the value
+    stmt = text('select x from test')
+    # Hint: https://docs.sqlalchemy.org/en/13/core/tutorial.html#specifying-result-column-behaviors
+    stmt = stmt.columns(x=List)
+    results = db.execute(stmt)
+    selected_value = results.fetchone()[0]
+    assert selected_value == insert_value
 
 
 def test_uuid(db):


### PR DESCRIPTION
Contains SQLAlchemy defined types for the following SQL types:

- NDARRAY
- NUMPY
- UUID
- REAL (tests only)
- DICT
- LIST

---

Note, these aren't actively used in the code base yet. This changeset only adds the logic. Later changesets will integrate them.

---

This can be squash merged if that's of interest.