### PR TITLE
Deprecate get and set metadata methods in favor of metadata property

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,6 +6,7 @@ colorama>=0.3.2
 dateutils>=0.6.6
 
 delorean
+deprecated
 docker
 flask>=0.10.1
 flask-cas

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -421,10 +421,10 @@ class SQLDatabaseController(object):
             def version(self, value):
                 if not value:
                     raise ValueError(value)
-                return self.ctrlr.executeone(
+                self.ctrlr.executeone(
                     f'INSERT OR REPLACE INTO {METADATA_TABLE_NAME} (metadata_key, metadata_value) VALUES (?, ?)',
                     ('database_version', value,),
-                )[0]
+                )
 
             @property
             def init_uuid(self):
@@ -438,10 +438,10 @@ class SQLDatabaseController(object):
             def init_uuid(self, value):
                 if not value:
                     raise ValueError(value)
-                return self.ctrlr.executeone(
+                self.ctrlr.executeone(
                     f'INSERT OR REPLACE INTO {METADATA_TABLE_NAME} (metadata_key, metadata_value) VALUES (?, ?)',
                     ('database_init_uuid', value,),
-                )[0]
+                )
 
             # collections.abc.MutableMapping abstract methods
 
@@ -1712,6 +1712,7 @@ class SQLDatabaseController(object):
         )
         return metadata_items
 
+    @deprecated('Use the metadata property instead')
     def set_metadata_val(self, key, val):
         """
         key must be given as a repr-ed string
@@ -2835,11 +2836,9 @@ class SQLDatabaseController(object):
                                         assert (
                                             self.metadata['contributors'].superkey is None
                                         ), 'hack failed2'
-                                        if True:
-                                            self.set_metadata_val(
-                                                'contributors_superkeys',
-                                                "[('" + superkey + "',)]",
-                                            )
+                                        self.metadata['contributors'].superkey = [
+                                            (superkey,)
+                                        ]
                                         return (superkey,)
                                     else:
                                         raise NotImplementedError(

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -2436,31 +2436,9 @@ class SQLDatabaseController(object):
         assert tablename in self.get_table_names(
             lazy=True
         ), 'tablename=%r is not a part of this database' % (tablename,)
-        superkey_colnames_list_repr = self.metadata[tablename].superkeys
-        # These asserts might not be valid, but in that case this function needs
-        # to be rewritten under a different name
-        # assert len(superkeys) == 1, 'INVALID DEVELOPER ASSUMPTION IN
-        # SQLCONTROLLER. MORE THAN 1 SUPERKEY'
-        if superkey_colnames_list_repr is None:
+        superkeys = self.metadata[tablename].superkeys
+        if superkeys is None:
             superkeys = []
-            pass
-        else:
-            # superkey_colnames = superkey_colnames_str.split(';')
-            # with ut.EmbedOnException():
-            if superkey_colnames_list_repr.find(';') > -1:
-                # SHOW NOT HAPPEN
-                # hack for old metadata superkey_val format
-                superkeys = [tuple(map(str, superkey_colnames_list_repr.split(';')))]
-            else:
-                # new evalable format
-                locals_ = {}
-                globals_ = {}
-                superkeys = eval(superkey_colnames_list_repr, globals_, locals_)
-        # superkeys = [
-        #    None if superkey_colname is None else str(superkey_colname)
-        #    for superkey_colname in superkey_colnames
-        # ]
-        superkeys = list(map(tuple, superkeys))
         return superkeys
 
     def get_table_primarykey_colnames(self, tablename):

--- a/wbia/tests/dtool/test_sql_control.py
+++ b/wbia/tests/dtool/test_sql_control.py
@@ -143,8 +143,8 @@ class TestMetadataProperty:
     def test_database_attributes(self):
         # Check the database version
         assert self.ctrlr.metadata.database.version == '0.0.0'
-        # Check the database init_uuid, verified via evaluating it
-        assert uuid.UUID(self.ctrlr.metadata.database.init_uuid)
+        # Check the database init_uuid is a valid uuid.UUID
+        assert isinstance(self.ctrlr.metadata.database.init_uuid, uuid.UUID)
 
     # ###
     # Test batch manipulation methods
@@ -253,4 +253,5 @@ class TestMetadataProperty:
             del self.ctrlr.metadata.database['init_uuid']
         with pytest.raises(ValueError):
             self.ctrlr.metadata.database['init_uuid'] = None
-        assert uuid.UUID(self.ctrlr.metadata.database.init_uuid)
+        # Check the value is still a uuid.UUID
+        assert isinstance(self.ctrlr.metadata.database.init_uuid, uuid.UUID)


### PR DESCRIPTION
Deprecating the use of `get_metadata_val` and `set_metadata_val` in favor of `ctrlr.metadata.<table>.<key>`, `ctrlr.metadata[<table>][<key>]` or a variation between attribute and key access (e.g. `ctrlr.metadata['images'].dependsmap`).

See individual commits for specific details.