### PR TITLE
Don't remove docker image in devops/publish.sh

### DIFF
--- a/devops/publish.sh
+++ b/devops/publish.sh
@@ -33,5 +33,4 @@ for IMG in $IMAGES; do
     docker tag wildme/${IMG}:latest ${IMG_PREFIX}${IMG}:${TAG}
     echo "Pushing ${IMG_PREFIX}${IMG}:${TAG}"
     docker push ${IMG_PREFIX}${IMG}:${TAG}
-    docker rmi wildme/${IMG}:latest
 done


### PR DESCRIPTION
We use `devops/publish.sh` to publish the docker images to docker hub
and github packages in two steps.  Nightly builds have been failing
because the code removes the image after publishing to github
packages... (Sorry :facepalm:)