### PR TITLE
Slim down docker image apt dependencies in base (#107)

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -31,6 +31,13 @@ COPY --from=org.wildme.wbia.build /virtualenv /virtualenv
 
 COPY --from=org.wildme.wbia.build /wbia /wbia
 
+RUN apt-get update \
+    && apt-get install -y \
+        libgtk-3-dev \
+        libtbb-dev \
+        libdc1394-22-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN ln -s /virtualenv/env3/lib/libgpuarray.so     /usr/lib/libgpuarray.so \
  && ln -s /virtualenv/env3/lib/libgpuarray.so.3   /usr/lib/libgpuarray.so.3 \
  && ln -s /virtualenv/env3/lib/libgpuarray.so.3.0 /usr/lib/libgpuarray.so.3.0

--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -6,7 +6,7 @@ ARG AZURE_DEVOPS_CACHEBUSTER=0
 
 RUN echo "ARGS AZURE_DEVOPS_CACHEBUSTER=${AZURE_DEVOPS_CACHEBUSTER}"
 
-# Install apt packages
+# Install requirements
 RUN apt-get update \
  && apt-get install -y \
         ca-certificates \
@@ -15,19 +15,12 @@ RUN apt-get update \
         libtbb2 \
         libtbb-dev \
         git \
-        tmux \
-        locate \
-        htop \
-        ipython \
-        ipython3 \
         python \
         python-dev \
         python-pip \
         python3 \
         python3-dev \
         python3-pip \
-        python3-gdbm \
-        graphviz \
         libeigen3-dev \
         libgraphviz-dev \
         libfreetype6-dev \
@@ -42,13 +35,11 @@ RUN apt-get update \
         libopenblas-dev \
         libtbb-dev \
         libtesseract-dev \
-        vim \
         libv4l-dev \
         libavcodec-dev \
         libavformat-dev \
         libswscale-dev \
         libavresample-dev \
-        ffmpeg \
         libpng-dev \
         libjpeg-dev \
         libopenjp2-7-dev \
@@ -56,7 +47,6 @@ RUN apt-get update \
         libtiff-dev \
         libwebp-dev \
         libdc1394-22-dev \
-        unzip \
         libxvidcore-dev \
         libx264-dev \
         libgtk-3-dev \
@@ -66,6 +56,20 @@ RUN apt-get update \
         tesseract-ocr-eng \
         liblz4-dev \
         libhdf5-serial-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install developer tools
+RUN apt-get update \
+ && apt-get install -y \
+        git \
+        tmux \
+        htop \
+        ipython \
+        ipython3 \
+        python3-gdbm \
+        graphviz \
+        vim \
+        unzip \
         xvfb \
  && rm -rf /var/lib/apt/lists/*
 

--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -12,50 +12,9 @@ RUN apt-get update \
         ca-certificates \
         build-essential \
         pkg-config \
-        libtbb2 \
-        libtbb-dev \
-        git \
-        python \
-        python-dev \
-        python-pip \
         python3 \
         python3-dev \
         python3-pip \
-        libeigen3-dev \
-        libgraphviz-dev \
-        libfreetype6-dev \
-        libgdal-dev \
-        libgl1-mesa-glx \
-        libgoogle-glog-dev \
-        libharfbuzz-dev \
-        libhdf5-dev \
-        liblapack-dev \
-        liblapacke-dev \
-        libleptonica-dev \
-        libopenblas-dev \
-        libtbb-dev \
-        libtesseract-dev \
-        libv4l-dev \
-        libavcodec-dev \
-        libavformat-dev \
-        libswscale-dev \
-        libavresample-dev \
-        libpng-dev \
-        libjpeg-dev \
-        libopenjp2-7-dev \
-        libopenexr22 \
-        libtiff-dev \
-        libwebp-dev \
-        libdc1394-22-dev \
-        libxvidcore-dev \
-        libx264-dev \
-        libgtk-3-dev \
-        libatlas-base-dev \
-        gfortran \
-        tesseract-ocr \
-        tesseract-ocr-eng \
-        liblz4-dev \
-        libhdf5-serial-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Install developer tools
@@ -73,9 +32,15 @@ RUN apt-get update \
         xvfb \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://get.docker.com -o get-docker.sh \
- && sh get-docker.sh
-
+# Install Docker CE
+RUN set -ex \
+ && apt-get update \
+ && apt-get install -y curl \
+ && curl -fsSL https://get.docker.com -o get-docker.sh \
+ && sh get-docker.sh \
+ && apt-get purge -y curl \
+ && rm -rf /var/lib/apt/lists/*
+ 
 # Create wbia source location
 RUN mkdir -p /wbia
 

--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -4,6 +4,59 @@ ARG AZURE_DEVOPS_CACHEBUSTER=0
 
 RUN echo "ARGS AZURE_DEVOPS_CACHEBUSTER=${AZURE_DEVOPS_CACHEBUSTER}"
 
+# Install OpenCV requirements
+RUN apt-get update \
+ && apt-get install -y \
+        ca-certificates \
+        build-essential \
+        pkg-config \
+        libtbb2 \
+        libtbb-dev \
+        git \
+        python \
+        python-dev \
+        python-pip \
+        python3 \
+        python3-dev \
+        python3-pip \
+        libeigen3-dev \
+        libgraphviz-dev \
+        libfreetype6-dev \
+        libgdal-dev \
+        libgl1-mesa-glx \
+        libgoogle-glog-dev \
+        libharfbuzz-dev \
+        libhdf5-dev \
+        liblapack-dev \
+        liblapacke-dev \
+        libleptonica-dev \
+        libopenblas-dev \
+        libtbb-dev \
+        libtesseract-dev \
+        libv4l-dev \
+        libavcodec-dev \
+        libavformat-dev \
+        libswscale-dev \
+        libavresample-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libopenjp2-7-dev \
+        libopenexr22 \
+        libtiff-dev \
+        libwebp-dev \
+        libdc1394-22-dev \
+        libxvidcore-dev \
+        libx264-dev \
+        libgtk-3-dev \
+        libatlas-base-dev \
+        gfortran \
+        tesseract-ocr \
+        tesseract-ocr-eng \
+        liblz4-dev \
+        libhdf5-serial-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+
 # Clone other Github repositories
 RUN git clone https://github.com/opencv/opencv.git                        /wbia/opencv \
  && git clone https://github.com/opencv/opencv_contrib.git                /wbia/opencv_contrib \

--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -114,6 +114,8 @@ RUN set -ex \
 
 RUN ln -s /virtualenv/env3/lib/python3.6/site-packages/cv2/python-3.6/cv2.cpython-36m-x86_64-linux-gnu.so /virtualenv/env3/lib/python3.6/site-packages/cv2.so
 
+RUN /bin/bash -xc '. /virtualenv/env3/bin/activate && python3 -c "import cv2; print(cv2.getBuildInformation())"'
+
 RUN /virtualenv/env3/bin/pip install \
     cython==0.28.1
 

--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -139,8 +139,6 @@ RUN set -ex \
 
 # Install basic Python3 dependencies (and ones that were missing in IBEIS install)
 RUN set -ex \
-    && apt-get update \
-    && apt-get install -y libgraphviz-dev \
     && /virtualenv/env3/bin/pip install \
     ipython==6.2.1 \
     pyqt5==5.10.1 \
@@ -166,13 +164,18 @@ RUN set -ex \
     line-profiler==2.1.2 \
     gdm==0.8.2 \
     prometheus-client==0.5.0 \
-    docker==4.0.2 \
- && rm -rf /var/lib/apt/lists/*
+    docker==4.0.2
 
 RUN /virtualenv/env3/bin/pip install git+https://github.com/aleju/imgaug \
  && /virtualenv/env3/bin/pip install git+https://github.com/cameronbwhite/Flask-CAS.git@10ee70466ac9e71cec3602c1cd46f0566618f67e \
- && /virtualenv/env3/bin/pip install git+https://github.com/pwaller/pyfiglet.git@6dabdb0e720b5a61d81ff819faf0ad86127275fc \
- && /virtualenv/env3/bin/pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/"
+ && /virtualenv/env3/bin/pip install git+https://github.com/pwaller/pyfiglet.git@6dabdb0e720b5a61d81ff819faf0ad86127275fc
+
+# Install pygraphviz (for developer use)
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y libgraphviz-dev \
+    && /virtualenv/env3/bin/pip install pygraphviz --install-option="--include-path=/usr/include/graphviz" --install-option="--library-path=/usr/lib/graphviz/" \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 RUN cd /wbia/Theano \

--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -148,10 +148,11 @@ RUN set -ex \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
-RUN cd /wbia/Theano \
- && /virtualenv/env3/bin/pip install -e . \
- && cd /wbia/networkx \
- && /virtualenv/env3/bin/pip install -e .
+RUN set -ex \
+    && cd /wbia/Theano \
+    && /virtualenv/env3/bin/pip install -e . \
+    && cd /wbia/networkx \
+    && /virtualenv/env3/bin/pip install -e .
 
 # Include libraries in virtualenv for python
 ENV LD_LIBRARY_PATH "/virtualenv/env3/lib:${LD_LIBRARY_PATH}"

--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -6,61 +6,32 @@ RUN echo "ARGS AZURE_DEVOPS_CACHEBUSTER=${AZURE_DEVOPS_CACHEBUSTER}"
 
 # Install OpenCV requirements
 RUN apt-get update \
- && apt-get install -y \
-        ca-certificates \
+    && apt-get install -y \
         build-essential \
+        cmake \
+        git \
         pkg-config \
+        libgtk-3-dev \
+        # libavcodec-dev \
+        # libavformat-dev \
+        libswscale-dev \
+        # libv4l-dev \
+        # libxvidcore-dev \
+        # libx264-dev \
+        libjpeg-dev \
+        libpng-dev \
+        libtiff-dev \
+        gfortran \
+        openexr \
+        libatlas-base-dev \
+        python3-dev \
         libtbb2 \
         libtbb-dev \
-        git \
-        python \
-        python-dev \
-        python-pip \
-        python3 \
-        python3-dev \
-        python3-pip \
-        libeigen3-dev \
-        libgraphviz-dev \
-        libfreetype6-dev \
-        libgdal-dev \
-        libgl1-mesa-glx \
-        libgoogle-glog-dev \
-        libharfbuzz-dev \
-        libhdf5-dev \
-        liblapack-dev \
-        liblapacke-dev \
-        libleptonica-dev \
-        libopenblas-dev \
-        libtbb-dev \
-        libtesseract-dev \
-        libv4l-dev \
-        libavcodec-dev \
-        libavformat-dev \
-        libswscale-dev \
-        libavresample-dev \
-        libpng-dev \
-        libjpeg-dev \
-        libopenjp2-7-dev \
-        libopenexr22 \
-        libtiff-dev \
-        libwebp-dev \
         libdc1394-22-dev \
-        libxvidcore-dev \
-        libx264-dev \
-        libgtk-3-dev \
-        libatlas-base-dev \
-        gfortran \
-        tesseract-ocr \
-        tesseract-ocr-eng \
-        liblz4-dev \
-        libhdf5-serial-dev \
- && rm -rf /var/lib/apt/lists/*
-
+    && rm -rf /var/lib/apt/lists/*
 
 # Clone other Github repositories
-RUN git clone https://github.com/opencv/opencv.git                        /wbia/opencv \
- && git clone https://github.com/opencv/opencv_contrib.git                /wbia/opencv_contrib \
- && git clone https://github.com/Theano/libgpuarray.git                   /wbia/libgpuarray \
+RUN git clone https://github.com/Theano/libgpuarray.git                   /wbia/libgpuarray \
  && git clone https://github.com/Theano/Theano.git                        /wbia/Theano \
  && git clone https://github.com/networkx/networkx.git                    /wbia/networkx
 
@@ -72,29 +43,40 @@ RUN /virtualenv/env3/bin/pip install \
 ARG OPENCV_VERSION=3.4.10
 
 # Install OpenCV
-RUN . /virtualenv/env3/bin/activate \
- && cd /wbia/opencv \
- && git checkout $OPENCV_VERSION \
- && cd /wbia/opencv_contrib \
- && git checkout $OPENCV_VERSION \
- && rm -rf /wbia/opencv/build \
- && mkdir -p /wbia/opencv/build \
- && cd /wbia/opencv/build \
- && cmake \
+RUN set -ex \
+    && cd /tmp \
+    && git clone https://github.com/opencv/opencv.git \
+    && git clone https://github.com/opencv/opencv_contrib.git \
+    && cd /tmp/opencv \
+    && git checkout $OPENCV_VERSION \
+    && cd /tmp/opencv_contrib \
+    && git checkout $OPENCV_VERSION \
+    && rm -rf /tmp/opencv/build \
+    && mkdir -p /tmp/opencv/build \
+    && cd /tmp/opencv/build \
+    && cmake -G "Unix Makefiles" \
      -D CMAKE_C_COMPILER=gcc \
      -D CMAKE_CXX_COMPILER=g++ \
      -D CMAKE_BUILD_TYPE=RELEASE \
      -D CMAKE_INSTALL_PREFIX=/virtualenv/env3 \
+     ############################################################
+     -D OPENCV_GENERATE_PKGCONFIG=ON \
      -D ENABLE_PRECOMPILED_HEADERS=OFF \
+     -D BUILD_opencv_apps=OFF \
+     -D BUILD_SHARED_LIBS=OFF \
+     -D BUILD_TESTS=OFF \
+     -D BUILD_PERF_TESTS=OFF \
      -D BUILD_DOCS=OFF \
-     -D BUILD_EXAMPLES=ON \
+     -D BUILD_EXAMPLES=OFF \
      -D BUILD_opencv_java=OFF \
      -D BUILD_opencv_python3=ON \
      -D BUILD_NEW_PYTHON_SUPPORT=ON \
      -D INSTALL_C_EXAMPLES=OFF \
-     -D INSTALL_PYTHON_EXAMPLES=ON \
+     -D INSTALL_PYTHON_EXAMPLES=OFF \
+     -D INSTALL_CREATE_DISTRIB=ON \
      -D BUILD_JPEG=ON \
      -D BUILD_HDR=ON \
+     -D BUILD_TIFF=ON \
      -D WITH_MATLAB=OFF \
      -D WITH_TBB=ON \
      -D WITH_CUDA=ON \
@@ -103,8 +85,15 @@ RUN . /virtualenv/env3/bin/activate \
      -D WITH_AVFOUNDATION=ON \
      -D WITH_JPEG=ON \
      -D WITH_HDR=ON \
-     -D WITH_V4L=ON \
+     -D WITH_V4L=OFF \
      -D WITH_GDAL=ON \
+     -D WITH_WIN32UI=OFF \
+     -D WITH_QT=OFF \
+     -D ENABLE_FAST_MATH=1 \
+     -D CUDA_FAST_MATH=1 \
+     -D OPENCV_ENABLE_NONFREE=ON \
+     -D OPENCV_EXTRA_MODULES_PATH=/tmp/opencv_contrib/modules \
+     ############################################################
      -D PYTHON_EXECUTABLE=/virtualenv/env3/bin/python \
      -D PYTHON_INCLUDE_DIR=/virtualenv/env3/include/python3.6m \
      -D PYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.6m.so \
@@ -115,16 +104,13 @@ RUN . /virtualenv/env3/bin/activate \
      -D PYTHON3_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.6m.so \
      -D PYTHON3_PACKAGES_PATH=/virtualenv/env3/lib/python3.6/site-packages \
      -D PYTHON3_NUMPY_INCLUDE_DIRS=/virtualenv/env3/lib/python3.6/site-packages/numpy/core/include \
-     -D ENABLE_FAST_MATH=1 \
-     -D CUDA_FAST_MATH=1 \
-     -D OPENCV_ENABLE_NONFREE=ON \
-     -D OPENCV_EXTRA_MODULES_PATH=/wbia/opencv_contrib/modules \
+     ############################################################
      .. \
- && make -j2 \
- && make install \
- && ldconfig \
- && cd .. \
- && rm -rf /wbia/opencv/build
+    && make -j9 \
+    && make install \
+    && ldconfig \
+    && cd .. \
+    && rm -rf /tmp/*
 
 RUN ln -s /virtualenv/env3/lib/python3.6/site-packages/cv2/python-3.6/cv2.cpython-36m-x86_64-linux-gnu.so /virtualenv/env3/lib/python3.6/site-packages/cv2.so
 
@@ -132,7 +118,8 @@ RUN /virtualenv/env3/bin/pip install \
     cython==0.28.1
 
 # Install libgpuarray (pygpu)
-RUN cd /wbia/libgpuarray \
+RUN set -ex \
+ && cd /wbia/libgpuarray \
  && git checkout 04c2892 \
  && mkdir -p /wbia/libgpuarray/build \
  && cd /wbia/libgpuarray/build \
@@ -147,8 +134,12 @@ RUN cd /wbia/libgpuarray \
  && /virtualenv/env3/bin/pip install -e . \
  && rm -rf /wbia/libgpuarray/build
 
+
 # Install basic Python3 dependencies (and ones that were missing in IBEIS install)
-RUN /virtualenv/env3/bin/pip install \
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y libgraphviz-dev \
+    && /virtualenv/env3/bin/pip install \
     ipython==6.2.1 \
     pyqt5==5.10.1 \
     Pillow==6.2.1 \
@@ -173,7 +164,8 @@ RUN /virtualenv/env3/bin/pip install \
     line-profiler==2.1.2 \
     gdm==0.8.2 \
     prometheus-client==0.5.0 \
-    docker==4.0.2
+    docker==4.0.2 \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN /virtualenv/env3/bin/pip install git+https://github.com/aleju/imgaug \
  && /virtualenv/env3/bin/pip install git+https://github.com/cameronbwhite/Flask-CAS.git@10ee70466ac9e71cec3602c1cd46f0566618f67e \

--- a/devops/dependencies/Dockerfile
+++ b/devops/dependencies/Dockerfile
@@ -136,38 +136,8 @@ RUN set -ex \
  && /virtualenv/env3/bin/pip install -e . \
  && rm -rf /wbia/libgpuarray/build
 
-
-# Install basic Python3 dependencies (and ones that were missing in IBEIS install)
 RUN set -ex \
-    && /virtualenv/env3/bin/pip install \
-    ipython==6.2.1 \
-    pyqt5==5.10.1 \
-    Pillow==6.2.1 \
-    futures_actors==0.0.5 \
-    scikit-image==0.15.0 \
-    mako==1.0.7 \
-    boto==2.49.0 \
-    colorama==0.3.9 \
-    jupyter==1.0.0 \
-    ansi2html==1.5.2 \
-    shapely==1.6.4.post2 \
-    pyshp==2.1.0 \
-    setproctitle==1.1.10 \
-    matplotlib==3.0.2 \
-    torch==1.0.1.post2 \
-    torchvision==0.2.1 \
-    flask_swagger==0.2.13 \
-    PyQt5-sip==4.19.13 \
-    sip==4.19.8 \
-    tqdm==4.26.0 \
-    pytesseract==0.2.6 \
-    line-profiler==2.1.2 \
-    gdm==0.8.2 \
-    prometheus-client==0.5.0 \
-    docker==4.0.2
-
-RUN /virtualenv/env3/bin/pip install git+https://github.com/aleju/imgaug \
- && /virtualenv/env3/bin/pip install git+https://github.com/cameronbwhite/Flask-CAS.git@10ee70466ac9e71cec3602c1cd46f0566618f67e \
+ && /virtualenv/env3/bin/pip install git+https://github.com/aleju/imgaug \
  && /virtualenv/env3/bin/pip install git+https://github.com/pwaller/pyfiglet.git@6dabdb0e720b5a61d81ff819faf0ad86127275fc
 
 # Install pygraphviz (for developer use)

--- a/devops/provision/Dockerfile
+++ b/devops/provision/Dockerfile
@@ -60,12 +60,22 @@ RUN . /virtualenv/env3/bin/activate \
  && pip install scikit-build
 
 # Build Python repositories with external codebases
-RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
- && cd /wbia/flann \
- && /bin/bash run_developer_setup.sh'
-RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
- && cd /wbia/hesaff \
- && /bin/bash run_developer_setup.sh'
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y \
+        liblz4-dev \
+    && /bin/bash -xc '. /virtualenv/env3/bin/activate \
+        && cd /wbia/flann \
+        && /bin/bash run_developer_setup.sh' \
+    && rm -rf /var/lib/apt/lists/*
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y \
+        libhdf5-serial-dev \
+    && /bin/bash -xc '. /virtualenv/env3/bin/activate \
+        && cd /wbia/hesaff \
+        && /bin/bash run_developer_setup.sh' \
+    && rm -rf /var/lib/apt/lists/*
 RUN /bin/bash -xc '. /virtualenv/env3/bin/activate \
  && cd /wbia/brambox \
  && /virtualenv/env3/bin/pip install -e .'


### PR DESCRIPTION
- Move the developer tools into a separate step

  Try to differentiate which packages are requirements needed for
  installation and/or runtime.

- Move opencv build dependencies

  Let's make base unaware of what it might be doing downstream. If we
  slim down the base to CUDA and some basic python structure, we may be
  able to reuse it for the slim runtime.

- Slim down the build requirements to the absolute necesseties


- Fix needed build requirements for flann and hesaff


- Check for the installation of opencv

  This gives a bit of debug information. It appears that
  `python-opencv-headless` is a the actively installed distribution. Our
  opencv is install but not the in use version. The header files are
  still found for builds, which is the important part.

- Fix to install libgraphviz-dev for pygraphviz

  Moving this to the action that requires it.

- Remove python dependencies in favor of requirements.txt

  Some of these mentioned packages are developer tools, but others
  overlap with the those installed for the application. Removing in
  favor of bring them back as needed.

- Add execution printing to python package installs

  When there is an issue with the installation of these, it's sometimes
  difficult to know which one is having the issue. This helps clear that
  up by printing (in red text) the commands as they are executed.

---

Michael did all the commits, I did some fixes (merged into the original commits) and rebased the branch.