### PR TITLE
Add event listener to map user-defined types during reflection

### DIFF
--- a/wbia/dtool/events.py
+++ b/wbia/dtool/events.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Definition of SQLAlchemy event listeners
+
+See also, https://docs.sqlalchemy.org/en/latest/core/event.html
+
+"""
+from sqlalchemy import event
+from sqlalchemy.schema import Table
+
+from .types import SQL_TYPE_TO_SA_TYPE
+
+
+# TODO (26-Sept-12020) Cache the results of this function.
+def _discovery_table_columns(inspector, table_name):
+    """Discover the original column type information in a _dialect_ specific way"""
+    dialect = inspector.engine.dialect.name
+    with inspector.engine.connect() as conn:
+        if dialect == 'sqlite':
+            # See also, https://sqlite.org/pragma.html#pragma_table_info
+            result = conn.execute(f"PRAGMA TABLE_INFO('{table_name}')")
+            #: column-id, name, data-type, nullable, default-value, is-primary-key
+            info_rows = result.fetchall()
+            names_to_types = {info[1]: info[2] for info in info_rows}
+        else:
+            raise RuntimeError(
+                "Unknown dialect ('{dialect}'), can't introspect column information."
+            )
+    return names_to_types
+
+
+def _discover_specific_type(inspector, table_name, column_name):
+    """Discover the specific type for a table's column.
+
+    Args:
+        inspector (Inspector): SQLAlchemy Inspector instance
+        table_name (str): name of the table
+        column_name (str): name of the column
+
+    Returns:
+        _ (str): type as defined in SQL
+
+    """
+    names_to_types = _discovery_table_columns(inspector, table_name)
+    #: No need to check for existence, because we already know it's been found by SQLAlchemy
+    return names_to_types[column_name]
+
+
+@event.listens_for(Table, 'column_reflect')
+def assign_user_defined_types_on_column_reflect(inspector, table, column_info):
+    """Assigns our ``UserDefinedType``s on :class:`Table` reflection.
+
+    See also, https://docs.sqlalchemy.org/en/latest/core/events.html#sqlalchemy.events.DDLEvents.column_reflect
+
+    """
+    # Unfortunately the `column_info` doesn't provide info about the original type text.
+    data_type = _discover_specific_type(inspector, table.name, column_info['name'])
+    try:
+        # Map the SQL data-type to our SQLAlchemy user-defined type
+        column_cls = SQL_TYPE_TO_SA_TYPE[data_type]
+    except KeyError:
+        pass  # Not one of our types
+    else:
+        # Assign the user-defined column type
+        column_info['type'] = column_cls()

--- a/wbia/dtool/types.py
+++ b/wbia/dtool/types.py
@@ -15,11 +15,11 @@ __all__ = (
     'List',
     'NDArray',
     'Number',
-    'TYPE_TO_SQLTYPE',
+    'SQL_TYPE_TO_SA_TYPE',
     'UUID',
 )
 
-
+# DDD (26-Sept-12020) Deprecated in favor of SQL_TYPE_TO_SA_TYPE
 TYPE_TO_SQLTYPE = {
     np.ndarray: 'NDARRAY',
     uuid.UUID: 'UUID',
@@ -179,3 +179,8 @@ class UUID(UserDefinedType):
                     return value
 
         return process
+
+
+_USER_DEFINED_TYPES = (Dict, List, NDArray, Number, UUID)
+# SQL type (e.g. 'DICT') to SQLAlchemy type:
+SQL_TYPE_TO_SA_TYPE = {cls().get_col_spec(): cls for cls in _USER_DEFINED_TYPES}

--- a/wbia/tests/dtool/test_events.py
+++ b/wbia/tests/dtool/test_events.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+import pytest
+from sqlalchemy import Column, MetaData, Table, Integer
+from sqlalchemy.engine import create_engine
+
+# On import the events will be registered with SQLAlchemy.
+# Therefore, the testing target is whatever triggers registered the event listeners.
+import wbia.dtool.events  # noqa
+from wbia.dtool import types
+
+
+@pytest.fixture(autouse=True)
+def db():
+    engine = create_engine('sqlite:///:memory:', echo=False)
+    with engine.connect() as conn:
+        yield conn
+
+
+TYPES = [
+    types.Dict,
+    types.List,
+    types.NDArray,
+    types.Number,
+    types.UUID,
+]
+
+
+def _make_comparable_Table_Columns(table):
+    """Given a SQLAlchemy Table, iterate over the columns
+    to make a comparable object with another table's columns
+
+    """
+    return {c.name: c.type.__class__ for c in table.columns}
+
+
+def test_column_reflection(db):
+    """Creates a table that uses all of our ``UserDefinedType``s defined in ``wbia.dtool.types``"""
+    table_name = 'test_udt'
+    creation_md = MetaData()
+    creation_columns = [Column(chr(97 + i), type_) for i, type_ in enumerate(TYPES)]
+    # Create the table
+    defined_table = Table(
+        table_name,
+        creation_md,
+        Column('id', Integer(), primary_key=True),
+        *creation_columns
+    )
+    defined_table.create(db.engine)
+
+    # Create a new metadata object to test reflection
+    md = MetaData()
+    # Just insure the new metadata object is empty
+    assert len(md.tables) == 0
+
+    # Call the target that calls the event code
+    reflected_table = Table(table_name, md, autoload=True, autoload_with=db.engine)
+
+    # Note, the id column is useful for testing the exception case in the event listener,
+    # but we need not compare it. Also, it gets reflected as a slightly different type.
+    def drop_id_column(columns):
+        {k: v for k, v in columns.items() if k != 'id'}
+
+    reflected_columns = drop_id_column(_make_comparable_Table_Columns(reflected_table))
+    defined_columns = drop_id_column(_make_comparable_Table_Columns(defined_table))
+    assert reflected_columns == defined_columns


### PR DESCRIPTION
Maps our user-defined types during SQLAlchemy table reflection. That
is to say, this will assign our column type definitions to a reflected
table. That means it'll generate a table that is near exactly what the
developer would define from scratch.

For example, if we have a table that has a `DICT` type column:

```
CREATE TABLE foo (id INTEGER PRIMARY KEY, d DICT);
```

The logic in this commit allows us to hook into the reflection
introspection process to change the column type. That looks something
like:

```
t = Table('foo', metadata, autoload=True, autoload_with=engine)
t.columns.d.type.__class__ == Dict
```