### PR TITLE
Put quotes around devops base python package versions

### DIFF
--- a/devops/base/Dockerfile
+++ b/devops/base/Dockerfile
@@ -81,11 +81,11 @@ RUN set -ex \
         pip \
  && /virtualenv/env3/bin/pip install --upgrade \
         # Install build requirements
-        cmake!=3.18.2 \
+        'cmake!=3.18.2' \
         ninja \
         scikit-build \
-        setuptools>=42 \
-        setuptools_scm[toml]>=3.4 \
+        'setuptools>=42' \
+        'setuptools_scm[toml]>=3.4' \
         cython \
         # Install OpenCV dependencies
         numpy \


### PR DESCRIPTION
We didn't put quotes around the package versions, causing `setuptools>=42` to
create a file `=42` in the root directory.

```
(env3) root@f36c5a2313f9:/wbia/wildbook-ia# ls /
'=3.4'   bin    dev   get-docker.sh   lib     media   opt    root   sbin   sys   usr   virtualenv
'=42'    boot   etc   home            lib64   mnt     proc   run    srv    tmp   var   wbia
```