### PR TITLE
Set target branch to "develop" in dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+# package_manager, directory, update_schedule are required properties
+# See https://dependabot.com/docs/config-file/
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    target_branch: "develop"


### PR DESCRIPTION
Remember this only takes effect once this commit makes it to the default branch ("master").