### PR TITLE
Run slowest tests only with "--slow" flag

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -70,4 +70,4 @@ jobs:
         run: |
           mkdir -p data/work
           python -m wbia --set-workdir data/work --preload-exit
-          pytest
+          pytest --slow

--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ def pytest_addoption(parser):
     parser.addoption('--fixme', action='store_true')
     parser.addoption('--gui', action='store_true')
     parser.addoption('--show', action='store_true')
+    parser.addoption('--slow', action='store_true')
     parser.addoption('--tomcat', action='store_true')
     parser.addoption('--web-tests', action='store_true')
     parser.addoption('--weird', action='store_true')

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ single-quotes = true
 
 [tool:pytest]
 minversion = 5.4
-addopts = -p no:doctest --xdoctest --xdoctest-style=google -r fEs
+addopts = -v -p no:doctest --xdoctest --xdoctest-style=google -r fEs
 testpaths =
     wbia
 filterwarnings =

--- a/wbia/algo/graph/mixin_loops.py
+++ b/wbia/algo/graph/mixin_loops.py
@@ -44,6 +44,7 @@ class InfrLoops(object):
             python -m wbia.algo.graph.mixin_loops main_gen
 
         Doctest:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> from wbia.algo.graph.mixin_loops import *
             >>> from wbia.algo.graph.mixin_simulation import UserOracle
             >>> import wbia

--- a/wbia/algo/graph/mixin_matching.py
+++ b/wbia/algo/graph/mixin_matching.py
@@ -258,6 +258,7 @@ class AnnotInfrMatching(object):
             python -m wbia.algo.graph.core _cm_training_pairs
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.graph.core import *  # NOQA
             >>> infr = testdata_infr('PZ_MTEST')
@@ -366,6 +367,7 @@ class AnnotInfrMatching(object):
             python -m wbia.algo.graph.core apply_match_scores --show
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.graph.core import *  # NOQA
             >>> infr = testdata_infr('PZ_MTEST')
@@ -448,7 +450,7 @@ class InfrLearning(object):
             python -m wbia.algo.graph.mixin_matching learn_evaluation_verifiers
 
         Doctest:
-            >>> # xdoctest: +REQUIRES(module:wbia_cnn)
+            >>> # xdoctest: +REQUIRES(module:wbia_cnn, --slow)
             >>> import wbia
             >>> infr = wbia.AnnotInference(
             >>>     'PZ_MTEST', aids='all', autoinit='annotmatch',
@@ -742,6 +744,7 @@ class CandidateSearch(_RedundancyAugmentation):
         """
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.graph import demo
             >>> infr = demo.demodata_mtest_infr()

--- a/wbia/algo/hots/chip_match.py
+++ b/wbia/algo/hots/chip_match.py
@@ -217,6 +217,7 @@ class _ChipMatchVisualization(object):
             python -m wbia --tf _ChipMatchVisualization.show_single_namematch --show --rank=2 --qaid=1 --save rank2.jpg
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.hots.chip_match import *  # NOQA
             >>> import wbia
@@ -341,6 +342,7 @@ class _ChipMatchVisualization(object):
             python -m wbia.algo.hots.chip_match show_single_annotmatch --show --qaids=5245 --daids=5161 --db PZ_Master1
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.hots.chip_match import *  # NOQA
             >>> ibs, qreq_, cm_list = plh.testdata_post_sver('PZ_MTEST', qaid_list=[18])
@@ -352,6 +354,7 @@ class _ChipMatchVisualization(object):
             >>> ut.show_if_requested()
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.hots.chip_match import *  # NOQA
             >>> # Make sure we can show results against an aid that wasn't matched
@@ -549,6 +552,7 @@ class _ChipMatchVisualization(object):
             python -m wbia.algo.hots.chip_match --exec-_ChipMatchVisualization.ishow_analysis --show
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.hots.chip_match import *  # NOQA
             >>> qaid = 18
@@ -857,6 +861,7 @@ class _ChipMatchScorers(object):
             python -m wbia.algo.hots.chip_match --test-score_annot_csum --show --qaid 18
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.hots.chip_match import *  # NOQA
             >>> ibs, qreq_, cm_list = plh.testdata_post_sver()

--- a/wbia/algo/hots/neighbor_index.py
+++ b/wbia/algo/hots/neighbor_index.py
@@ -136,6 +136,7 @@ def invert_index(vecs_list, fgws_list, ax_list, fxs_list, verbose=ut.NOT_QUIET):
         output depth_profile = [(8, 16), 1, 8, 8]
 
     Example:
+        >>> # xdoctest: +REQUIRES(--slow)
         >>> # ENABLE_DOCTEST
         >>> from wbia.algo.hots.neighbor_index import *  # NOQA
         >>> import wbia

--- a/wbia/algo/hots/tests/test_lnbnn.py
+++ b/wbia/algo/hots/tests/test_lnbnn.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 import logging
+import sys  # noqa
+
 import utool as ut
+import pytest
 
 (print, rrr, profile) = ut.inject2(__name__)
 logger = logging.getLogger('wbia')
 
 
+@pytest.mark.skipif("'--slow' not in sys.argv")
 def test_lnbnn():
     import wbia
 

--- a/wbia/algo/smk/inverted_index.py
+++ b/wbia/algo/smk/inverted_index.py
@@ -395,6 +395,7 @@ class InvertedAnnots(InvertedAnnotsExtras):
         Compute a per-word weight like idf
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.smk.inverted_index import *  # NOQA
             >>> qreq_, inva = testdata_inva()
@@ -432,6 +433,7 @@ class InvertedAnnots(InvertedAnnotsExtras):
     def compute_gammas(inva, alpha, thresh):
         """
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.smk.inverted_index import *  # NOQA
             >>> qreq_, inva = testdata_inva()

--- a/wbia/algo/smk/smk_pipeline.py
+++ b/wbia/algo/smk/smk_pipeline.py
@@ -371,6 +371,7 @@ class SMK(ut.NiceRepr):
             python -m wbia SMK.match_single -a ctrl --profile --db GZ_ALL
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # FUTURE_ENABLE
             >>> from wbia.algo.smk.smk_pipeline import *  # NOQA
             >>> import wbia

--- a/wbia/algo/verif/deploy.py
+++ b/wbia/algo/verif/deploy.py
@@ -447,7 +447,7 @@ class Deployer(object):
                 * PUBLISH TO /media/hdd/PUBLIC/models/pairclf
 
         Example:
-            >>> # xdoctest: +REQUIRES(module:wbia_cnn)
+            >>> # xdoctest: +REQUIRES(module:wbia_cnn, --slow)
             >>> from wbia.algo.verif.vsone import *  # NOQA
             >>> params = dict(sample_method='random')
             >>> pblm = OneVsOneProblem.from_empty('PZ_MTEST', **params)

--- a/wbia/algo/verif/pairfeat.py
+++ b/wbia/algo/verif/pairfeat.py
@@ -296,7 +296,7 @@ class PairwiseFeatureExtractor(object):
         object (feature corresopndences) doesnt directly provide.
 
         Example:
-            >>> # xdoctest: +REQUIRES(module:wbia_cnn)
+            >>> # xdoctest: +REQUIRES(module:wbia_cnn, --slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.algo.verif.pairfeat import *  # NOQA
             >>> import wbia

--- a/wbia/algo/verif/vsone.py
+++ b/wbia/algo/verif/vsone.py
@@ -67,7 +67,7 @@ class OneVsOneProblem(clf_helpers.ClfProblem):
         python -m wbia.algo.verif.vsone evaluate_classifiers --db testdb1 --show -a default
 
     Example:
-        >>> # xdoctest: +REQUIRES(module:wbia_cnn)
+        >>> # xdoctest: +REQUIRES(module:wbia_cnn, --slow)
         >>> from wbia.algo.verif.vsone import *  # NOQA
         >>> pblm = OneVsOneProblem.from_empty('PZ_MTEST')
         >>> pblm.hyper_params['xval_kw']['n_splits'] = 10

--- a/wbia/core_annots.py
+++ b/wbia/core_annots.py
@@ -891,7 +891,7 @@ def postprocess_mask(mask, thresh=20, kernel_size=20):
         rowid_kw = dict(config=config)
 
     Doctest:
-        >>> # xdoctest: +REQUIRES(module:wbia_cnn)
+        >>> # xdoctest: +REQUIRES(module:wbia_cnn, --slow)
         >>> from wbia.core_annots import *  # NOQA
         >>> import wbia.plottool as pt
         >>> ibs, depc, aid_list = testdata_core()

--- a/wbia/expt/test_result.py
+++ b/wbia/expt/test_result.py
@@ -560,6 +560,7 @@ class TestResult(ut.NiceRepr):
             ut.lmap(sum, ut.apply_grouping([len(ut.unique(ibs.annots(aids))) for aids in testres.cfgx2_qaids], testres.get_cfgx_groupxs()))
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.expt.test_result import *  # NOQA
             >>> from wbia.init import main_helpers
@@ -1938,6 +1939,7 @@ class TestResult(ut.NiceRepr):
             python -m wbia.expt.test_result --exec-get_truth2_prop --show
 
         Example:
+            >>> # xdoctest: +REQUIRES(--slow)
             >>> # ENABLE_DOCTEST
             >>> from wbia.expt.test_result import *  # NOQA
             >>> import wbia

--- a/wbia/plottool/interact_matches.py
+++ b/wbia/plottool/interact_matches.py
@@ -27,7 +27,7 @@ class MatchInteraction2(BASE_CLASS):
 
 
     Example:
-        >>> # xdoctest: +REQUIRES(module:wbia)
+        >>> # xdoctest: +REQUIRES(module:wbia, --slow)
         >>> from wbia.plottool.interact_matches import *  # NOQA
         >>> import wbia
         >>> # build test data

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -124,6 +124,7 @@ def annot_src_api(rowid=None, fresh=False, **kwargs):
     Returns the image file of annot <aid>
 
     Example:
+        >>> # xdoctest: +REQUIRES(--slow)
         >>> # WEB_DOCTEST
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
@@ -171,6 +172,7 @@ def background_src_api(rowid=None, fresh=False, **kwargs):
     Returns the image file of annot <aid>
 
     Example:
+        >>> # xdoctest: +REQUIRES(--slow)
         >>> # WEB_DOCTEST
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia

--- a/wbia/web/graph_server.py
+++ b/wbia/web/graph_server.py
@@ -177,7 +177,7 @@ class GraphActor(GRAPH_ACTOR_CLASS):
 
 
     Doctest:
-        >>> # xdoctest: +REQUIRES(module:wbia_cnn)
+        >>> # xdoctest: +REQUIRES(module:wbia_cnn, --slow)
         >>> from wbia.web.graph_server import *
         >>> import wbia
         >>> actor = GraphActor()

--- a/wbia/web/job_engine.py
+++ b/wbia/web/job_engine.py
@@ -352,6 +352,7 @@ def get_job_metadata(ibs, jobid):
         python -m wbia.web.job_engine --exec-get_job_metadata:0 --fg
 
     Example:
+        >>> # xdoctest: +REQUIRES(--slow)
         >>> # WEB_DOCTEST
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia


### PR DESCRIPTION
I ran `pytest --durations=10` to find out the slowest 10 tests:

```
599.58s call     wbia/algo/graph/mixin_matching.py::InfrLearning.learn_evaluation_verifiers:0
235.24s call     wbia/algo/hots/tests/test_lnbnn.py::test_lnbnn
112.55s call     wbia/algo/smk/smk_pipeline.py::SMK.match_single:0
96.87s call     wbia/algo/graph/mixin_matching.py::CandidateSearch.find_lnbnn_candidate_edges:0
57.68s call     wbia/algo/hots/chip_match.py::_ChipMatchVisualization.show_single_namematch:0
35.15s call     wbia/expt/test_result.py::TestResult.get_truth2_prop:0
25.27s call     wbia/algo/smk/inverted_index.py::InvertedAnnots.compute_word_weights:0
18.80s call     wbia/expt/test_result.py::TestResult.get_cfgx_groupxs:0
10.69s call     wbia/algo/graph/mixin_loops.py::InfrLoops.main_gen:0
10.25s call     wbia/algo/graph/mixin_matching.py::AnnotInfrMatching._cm_training_pairs:0
```

I added `# xdoctest: +REQUIRES(--slow)` to the tests so our tests
(without `--slow`) run faster.

After doing this a few times, I marked 26 tests as slow.  (Every time I
marked a test as slow, a different test becomes slow)
