### PR TITLE
Expose the background job engine worker process alive status

### DIFF
--- a/wbia/web/app.py
+++ b/wbia/web/app.py
@@ -16,6 +16,10 @@ import utool as ut
 (print, rrr, profile) = ut.inject2(__name__)
 logger = logging.getLogger('wbia')
 
+
+logger.setLevel(logging.INFO)
+
+
 try:
     try:
         from werkzeug.wsgi import DispatcherMiddleware

--- a/wbia/web/prometheus.py
+++ b/wbia/web/prometheus.py
@@ -63,6 +63,11 @@ PROMETHEUS_DATA = {
         'Job engine status',
         ['status', 'name', 'endpoint'],
     ),
+    'process': Gauge(
+        'wbia_engine_dead_process',
+        'Job engine status',
+        ['name', 'process'],
+    ),
     'elapsed': Gauge(
         'wbia_elapsed_seconds',
         'Number of elapsed seconds for the current working job',
@@ -355,6 +360,17 @@ def prometheus_update(ibs, *args, **kwargs):
                             PROMETHEUS_DATA['engine'].labels(
                                 status=status, name=container_name, endpoint=endpoint
                             ).set(number)
+                except Exception:
+                    pass
+
+                try:
+                    # logger.info(ut.repr3(status_dict))
+                    process_status_dict = ibs.get_process_alive_status()
+                    for process in process_status_dict:
+                        number = 0 if process_status_dict.get(process, False) else 1
+                        PROMETHEUS_DATA['process'].labels(
+                            process=process, name=container_name
+                        ).set(number)
                 except Exception:
                     pass
         try:


### PR DESCRIPTION
This PR exposes the background engine job status to the API (`[GET / POST] /api/engine/process/status/`) and via Prometheus reporting:

```
# HELP wbia_engine_dead_process Job engine status
# TYPE wbia_engine_dead_process gauge
wbia_engine_dead_process{name="testdb1",process="engine_queue"} 0.0
wbia_engine_dead_process{name="testdb1",process="collect_queue"} 0.0
wbia_engine_dead_process{name="testdb1",process="collector"} 0.0
wbia_engine_dead_process{name="testdb1",process="engine.fast.0"} 0.0
wbia_engine_dead_process{name="testdb1",process="engine.fast.1"} 0.0
wbia_engine_dead_process{name="testdb1",process="engine.slow.0"} 0.0
wbia_engine_dead_process{name="testdb1",process="engine.slow.1"} 0.0
```