### PR TITLE
Fix ImportError on dev script

### DIFF
--- a/wbia/dev.py
+++ b/wbia/dev.py
@@ -61,7 +61,7 @@ try:
     config.gpu_options.allow_growth = True
     sess = tf.Session(config=config)
     K.set_session(sess)
-except RuntimeError:
+except (ImportError, RuntimeError):
     pass
 
 from wbia._devscript import devcmd, DEVCMD_FUNCTIONS, DEVPRECMD_FUNCTIONS


### PR DESCRIPTION
Assuming tensorflow and keras as still optional, this change catches
when it's missing without pulling down the script.

I'm assuming because they are listed in `requirements/optional.txt`. I
could be wrong about this, but more importantly at the moment...
This corrects the error in CI; tests now pass.