### PR TITLE
Package wbia web templates and static files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ KWARGS = OrderedDict(
     packages=find_packages(),
     package_dir={'wbia': 'wbia'},
     python_requires='>=3.6, <4',
-    include_package_data=False,
+    include_package_data=True,
     # List of classifiers available at:
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[


### PR DESCRIPTION
`wbia/web/templates` and `wbia/web/static` were missing from the
wildbook-ia package on pypi.  They are included simply by changing
`include_package_data` to `True` in `setup.py`.

Closes #134