### PR TITLE
Change StopIteration to return in generators

### DIFF
--- a/wbia/algo/graph/nx_edge_augmentation.py
+++ b/wbia/algo/graph/nx_edge_augmentation.py
@@ -1044,7 +1044,7 @@ def greedy_k_edge_augmentation(G, k, avail=None, weight=None, seed=None):
 
     done = is_k_edge_connected(G, k)
     if done:
-        raise StopIteration()
+        return
     if avail is None:
         # all edges are available
         avail_uv = list(complement_edges(G))

--- a/wbia/algo/graph/nx_edge_kcomponents.py
+++ b/wbia/algo/graph/nx_edge_kcomponents.py
@@ -564,7 +564,7 @@ def general_k_edge_subgraphs(G, k):
     if G.number_of_nodes() < k:
         for node in G.nodes():
             yield G.subgraph([node]).copy()
-        raise StopIteration()
+        return
 
     # Intermediate results
     R0 = {G.subgraph(cc).copy() for cc in find_ccs(G)}

--- a/wbia/algo/verif/clf_helpers.py
+++ b/wbia/algo/verif/clf_helpers.py
@@ -1514,7 +1514,7 @@ class MultiClassLabels(ut.NiceRepr):
         """
         if labels.target_type == 'binary':
             yield labels
-            raise StopIteration()
+            return
         task_names_1vR = labels.one_vs_rest_task_names()
         for k in range(labels.n_classes):
             class_name = labels.class_names[k]

--- a/wbia/guitool/PrefWidget2.py
+++ b/wbia/guitool/PrefWidget2.py
@@ -775,7 +775,7 @@ class ConfigNodeWrapper(ut.NiceRepr):
 
     def iter_children(self):
         if self.children is None:
-            raise StopIteration()
+            return
         for child in self.children:
             yield child
 


### PR DESCRIPTION
Python 3.7 changed the way generators work.  Code like this:

```
def gen():
    yield 'a'
    yield 'b'
    raise StopIteration

for i in gen():
    print(i)
```

causes an exception in python 3.7:

```
(py3) root@f36c5a2313f9:/wbia/wildbook-ia# python3.6 /tmp/test_generator.py
a
b
(py3) root@f36c5a2313f9:/wbia/wildbook-ia# python3.7 /tmp/test_generator.py
a
b
Traceback (most recent call last):
  File "/tmp/test_generator.py", line 4, in gen
    raise StopIteration()
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/test_generator.py", line 6, in <module>
    for i in gen():
RuntimeError: generator raised StopIteration
```

It can be fixed by doing `return` instead of `raise StopIteration`.

Close #131