### PR TITLE
Change connection.commit to sqlalchemy transaction.commit

### DIFF
--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -703,9 +703,9 @@ class SQLDatabaseController(object):
 
     def shrink_memory(self):
         logger.info('[sql] shrink_memory')
-        self.connection.commit()
+        transaction = self.connection.begin()
         self.connection.execute('PRAGMA shrink_memory;')
-        self.connection.commit()
+        transaction.commit()
 
     def vacuum(self):
         logger.info('[sql] vaccum')
@@ -715,9 +715,9 @@ class SQLDatabaseController(object):
 
     def integrity(self):
         logger.info('[sql] vaccum')
-        self.connection.commit()
+        transaction = self.connection.begin()
         self.connection.execute('PRAGMA integrity_check;')
-        self.connection.commit()
+        transaction.commit()
 
     def squeeze(self):
         logger.info('[sql] squeeze')


### PR DESCRIPTION
sqlalchemy database connection doesn't have the method `.commit()`, we need to
create a transaction and commit it instead.

```
DOCTEST TRACEBACK
Traceback (most recent call last):
  File "/virtualenv/env3/lib/python3.7/site-packages/xdoctest/doctest_example.py", line 598, in run
    exec(code, test_globals)
  File "<doctest:/wbia/wildbook-ia/wbia/other/ibsfuncs.py::check_cache_purge:0>", line rel: 5, abs: 1251, in <module>
    >>> result = check_cache_purge(ibs)
  File "/wbia/wildbook-ia/wbia/other/ibsfuncs.py", line 1477, in check_cache_purge
    db.squeeze()
  File "/wbia/wildbook-ia/wbia/dtool/sql_control.py", line 726, in squeeze
    self.shrink_memory()
  File "/wbia/wildbook-ia/wbia/dtool/sql_control.py", line 708, in shrink_memory
    self.connection.commit()
AttributeError: 'Connection' object has no attribute 'commit'
DOCTEST REPRODUCTION
CommandLine:
    pytest /wbia/wildbook-ia/wbia/other/ibsfuncs.py::check_cache_purge:0
```