### PR TITLE
Named Dependency Caches with fewer filesystem ties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ testdb*/
 tmp.txt
 vsone.*.cPkl
 vsone.*.json
-wbia/DEPCACHE*/
+wbia/dtool/DEPCACHE*/
 
 # Translations
 *.mo

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -806,7 +806,7 @@ class IBEISController(BASE_CLASS):
     def _init_depcache(self):
         # Initialize dependency cache for images
         image_root_getters = {}
-        self.depc_image = dtool.DependencyCache.as_named(
+        self.depc_image = dtool.DependencyCache(
             self,
             const.IMAGE_TABLE,
             self.get_image_uuids,
@@ -830,7 +830,7 @@ class IBEISController(BASE_CLASS):
             'theta': self.get_annot_thetas,
             'occurrence_text': self.get_annot_occurrence_text,
         }
-        self.depc_annot = dtool.DependencyCache.as_named(
+        self.depc_annot = dtool.DependencyCache(
             self,
             const.ANNOTATION_TABLE,
             self.get_annot_visual_uuids,
@@ -845,7 +845,7 @@ class IBEISController(BASE_CLASS):
 
         # Initialize dependency cache for parts
         part_root_getters = {}
-        self.depc_part = dtool.DependencyCache.as_named(
+        self.depc_part = dtool.DependencyCache(
             self,
             const.PART_TABLE,
             self.get_part_uuids,

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -53,6 +53,7 @@ from wbia.dtool.dump import dump
 (print, rrr, profile) = ut.inject2(__name__)
 logger = logging.getLogger('wbia')
 
+
 # Import modules which define injectable functions
 
 # tuples represent conditional imports with the flags in the first part of the
@@ -361,6 +362,12 @@ class IBEISController(BASE_CLASS):
         self.table_cache = None
         self._initialize_self()
         self._init_dirs(dbdir=dbdir, ensure=ensure)
+
+        # FIXME (20-Oct-12020) Set the base URI
+        #       This is a temporary adjustment to obtain a URI where one would not
+        #       be present as part of this filesystem focused contructor.
+        self._base_uri = f'sqlite:///{self.get_ibsdir()}'
+
         # _send_wildbook_request will do nothing if no wildbook address is
         # specified
         self._send_wildbook_request(wbaddr)
@@ -389,6 +396,11 @@ class IBEISController(BASE_CLASS):
         self.https = const.HTTPS
 
         logger.info('[ibs.__init__] END new IBEISController\n')
+
+    @property
+    def base_uri(self):
+        """Base database URI without a specific database name"""
+        return self._base_uri
 
     def reset_table_cache(self):
         self.table_cache = accessor_decors.init_tablecache()

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -790,17 +790,15 @@ class IBEISController(BASE_CLASS):
     def _init_depcache(self):
         # Initialize dependency cache for images
         image_root_getters = {}
-        self.depc_image = dtool.DependencyCache(
-            root_tablename=const.IMAGE_TABLE,
-            default_fname=const.IMAGE_TABLE + '_depcache',
-            cache_dpath=self.get_cachedir(),
-            controller=self,
-            get_root_uuid=self.get_image_uuids,
+        self.depc_image = dtool.DependencyCache.as_named(
+            self,
+            const.IMAGE_TABLE,
+            self.get_image_uuids,
             root_getters=image_root_getters,
         )
         self.depc_image.initialize()
 
-        """ Need to reinit this sometimes if cache is ever deleted """
+        # Need to reinit this sometimes if cache is ever deleted
         # Initialize dependency cache for annotations
         annot_root_getters = {
             'name': self.get_annot_names,
@@ -816,13 +814,10 @@ class IBEISController(BASE_CLASS):
             'theta': self.get_annot_thetas,
             'occurrence_text': self.get_annot_occurrence_text,
         }
-        self.depc_annot = dtool.DependencyCache(
-            # root_tablename='annot',   # const.ANNOTATION_TABLE
-            root_tablename=const.ANNOTATION_TABLE,
-            default_fname=const.ANNOTATION_TABLE + '_depcache',
-            cache_dpath=self.get_cachedir(),
-            controller=self,
-            get_root_uuid=self.get_annot_visual_uuids,
+        self.depc_annot = dtool.DependencyCache.as_named(
+            self,
+            const.ANNOTATION_TABLE,
+            self.get_annot_visual_uuids,
             root_getters=annot_root_getters,
         )
         # backwards compatibility
@@ -834,12 +829,10 @@ class IBEISController(BASE_CLASS):
 
         # Initialize dependency cache for parts
         part_root_getters = {}
-        self.depc_part = dtool.DependencyCache(
-            root_tablename=const.PART_TABLE,
-            default_fname=const.PART_TABLE + '_depcache',
-            cache_dpath=self.get_cachedir(),
-            controller=self,
-            get_root_uuid=self.get_part_uuids,
+        self.depc_part = dtool.DependencyCache.as_named(
+            self,
+            const.PART_TABLE,
+            self.get_part_uuids,
             root_getters=part_root_getters,
         )
         self.depc_part.initialize()

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -402,6 +402,10 @@ class IBEISController(BASE_CLASS):
         """Base database URI without a specific database name"""
         return self._base_uri
 
+    def make_cache_db_uri(self, name):
+        """Given a name of the cache produce a database connection URI"""
+        return f'sqlite:///{self.get_cachedir()}/{name}.sqlite'
+
     def reset_table_cache(self):
         self.table_cache = accessor_decors.init_tablecache()
 

--- a/wbia/dtool/depcache_control.py
+++ b/wbia/dtool/depcache_control.py
@@ -86,51 +86,6 @@ def make_depcache_decors(root_tablename):
 class DependencyCache:
     def __init__(
         self,
-        root_tablename=None,
-        cache_dpath='./DEPCACHE',
-        controller=None,
-        default_fname=None,
-        # root_asobject=None,
-        get_root_uuid=None,
-        root_getters=None,
-        use_globals=True,
-    ):
-        if default_fname is None:
-            # ??? So 'None_primary_cache' is a good name?
-            default_fname = root_tablename + '_primary_cache'
-        self.root_getters = root_getters
-        # Root of all dependencies
-        self.root_tablename = root_tablename
-        self.name = root_tablename
-        # Directory all cachefiles are stored in
-        self.cache_dpath = ut.truepath(cache_dpath)
-        # Parent (ibs) controller
-        self.controller = controller
-        # Internal dictionary of dependant tables
-        self.cachetable_dict = {}
-        self.configclass_dict = {}
-        self.requestclass_dict = {}
-        self.resultclass_dict = {}
-        # Mapping of database connections by name
-        #  - names populated by _CoreDependencyCache._register_prop
-        #  - values populated by _CoreDependencyCache.initialize
-        self._db_by_name = {}
-        # Function to map a root rowid to an object
-        # self._root_asobject = root_asobject
-        self._use_globals = use_globals
-        self.default_fname = default_fname
-        if get_root_uuid is None:
-            logger.info('WARNING NEED UUID FUNCTION')
-            # HACK
-            get_root_uuid = ut.identity
-        self.get_root_uuid = get_root_uuid
-        self.delete_exclude_tables = {}
-        # BBB (25-Sept-12020) `_debug` remains around to be backwards compatible
-        self._debug = False
-
-    @classmethod
-    def as_named(
-        cls,
         controller,
         name,
         get_root_uuid,
@@ -150,8 +105,6 @@ class DependencyCache:
         """
         if table_name is None:
             table_name = name
-
-        self = cls.__new__(cls)
 
         self.name = name
         # Parent (ibs) controller
@@ -183,8 +136,6 @@ class DependencyCache:
         self.delete_exclude_tables = {}
         # BBB (25-Sept-12020) `_debug` remains around to be backwards compatible
         self._debug = False
-
-        return self
 
     def __repr__(self):
         return f'<DependencyCache(controller={self.controller} name={self.name})>'

--- a/wbia/dtool/depcache_control.py
+++ b/wbia/dtool/depcache_control.py
@@ -1071,6 +1071,61 @@ class DependencyCache(_CoreDependencyCache, ut.NiceRepr):
         # BBB (25-Sept-12020) `_debug` remains around to be backwards compatible
         self._debug = False
 
+    @classmethod
+    def as_named(
+        cls,
+        controller,
+        name,
+        get_root_uuid,
+        table_name=None,
+        root_getters=None,
+        use_globals=True,
+    ):
+        """
+        Args:
+            controller (IBEISController): main controller
+            name (str): name of this controller instance, which is used in naming the data storage
+            table_name (str): (optional) if not the same as the 'name'
+            get_root_uuid: ???
+            root_getters: ???
+            use_globals (bool): ??? (default: True)
+
+        """
+        if table_name is None:
+            table_name = name
+
+        self = cls.__new__(cls)
+
+        # Parent (ibs) controller
+        self.controller = controller
+        # Internal dictionary of dependant tables
+        self.cachetable_dict = {}
+        self.configclass_dict = {}
+        self.requestclass_dict = {}
+        self.resultclass_dict = {}
+
+        self.root_getters = root_getters
+        # Root of all dependencies
+        self.root_tablename = table_name
+        # XXX Directory all cachefiles are stored in
+        self.cache_dpath = ut.truepath(self.controller.get_cachedir())
+
+        # XXX Mapping of different files properties are stored in
+        self.fname_to_db = {}
+
+        # Function to map a root rowid to an object
+        self._use_globals = use_globals
+
+        # XXX remove filesystem name
+        self.default_fname = f'{table_name}_cache'
+
+        self.get_root_uuid = get_root_uuid
+        self.delete_exclude_tables = {}
+        # BBB (25-Sept-12020) `_debug` remains around to be backwards compatible
+        self._debug = False
+
+        return self
+
     def get_tablenames(self):
         return list(self.cachetable_dict.keys())
 

--- a/wbia/dtool/depcache_control.py
+++ b/wbia/dtool/depcache_control.py
@@ -223,17 +223,14 @@ class _CoreDependencyCache(object):
         #    pip install fs
 
         for fname in self._db_by_name.keys():
-            if fname == ':memory:':
-                db_uri = 'sqlite:///:memory:'
-            else:
-                fname_ = ut.ensure_ext(fname, '.sqlite')
-                from os.path import dirname
+            fname_ = ut.ensure_ext(fname, '.sqlite')
+            from os.path import dirname
 
-                prefix_dpath = dirname(fname_)
-                if prefix_dpath:
-                    ut.ensuredir(ut.unixjoin(self.cache_dpath, prefix_dpath))
-                fpath = ut.unixjoin(self.cache_dpath, fname_)
-                db_uri = 'sqlite:///{}'.format(os.path.realpath(fpath))
+            prefix_dpath = dirname(fname_)
+            if prefix_dpath:
+                ut.ensuredir(ut.unixjoin(self.cache_dpath, prefix_dpath))
+            fpath = ut.unixjoin(self.cache_dpath, fname_)
+            db_uri = 'sqlite:///{}'.format(os.path.realpath(fpath))
             # if ut.get_argflag('--clear-all-depcache'):
             #     ut.delete(fpath)
             db = sql_control.SQLDatabaseController.from_uri(db_uri)
@@ -1050,7 +1047,6 @@ class DependencyCache(_CoreDependencyCache, ut.NiceRepr):
         if default_fname is None:
             # ??? So 'None_primary_cache' is a good name?
             default_fname = root_tablename + '_primary_cache'
-            # default_fname = ':memory:'
         self.root_getters = root_getters
         # Root of all dependencies
         self.root_tablename = root_tablename

--- a/wbia/dtool/depcache_control.py
+++ b/wbia/dtool/depcache_control.py
@@ -148,14 +148,14 @@ class _CoreDependencyCache(object):
         if requestclass is not None:
             self.requestclass_dict[tablename] = requestclass
         self.fname_to_db[fname] = None
-        table = depcache_table.DependencyCacheTable(
-            depc=self,
+        table = depcache_table.DependencyCacheTable.from_name(
+            fname,
+            tablename,
+            self,
             parent_tablenames=parents,
-            tablename=tablename,
             data_colnames=colnames,
             data_coltypes=coltypes,
             preproc_func=preproc_func,
-            fname=fname,
             default_to_unpack=default_to_unpack,
             **kwargs,
         )

--- a/wbia/dtool/depcache_control.py
+++ b/wbia/dtool/depcache_control.py
@@ -189,6 +189,12 @@ class _CoreDependencyCache(object):
         for fname, db in self.fname_to_db.items():
             db.close()
 
+    def get_db_by_name(self, name):
+        """Get the database (i.e. SQLController) for the given database name"""
+        # FIXME (20-Oct-12020) Currently handled via a mapping of 'fname'
+        #       to database controller objects.
+        return self.fname_to_db[name]
+
     @profile
     def initialize(self, _debug=None):
         """

--- a/wbia/dtool/depcache_table.py
+++ b/wbia/dtool/depcache_table.py
@@ -1950,6 +1950,8 @@ class DependencyCacheTable(
         self.data_colnames = tuple(data_colnames)
         self.data_coltypes = data_coltypes
         self.preproc_func = preproc_func
+        #: Optional specification of the amount of blobs to modify in one SQL operation
+        self.chunksize = chunksize
 
         # Behavior
         self.on_delete = None
@@ -1960,7 +1962,6 @@ class DependencyCacheTable(
         self.rm_extern_on_delete = rm_extern_on_delete
 
         # XXX (20-Oct-12020) It's not clear if these attributes are absolutely necessary.
-        self.chunksize = chunksize
         # Developmental properties
         self.subproperties = {}
         self.isinteractive = isinteractive

--- a/wbia/dtool/depcache_table.py
+++ b/wbia/dtool/depcache_table.py
@@ -1865,7 +1865,6 @@ class DependencyCacheTable(
         except Exception:
             # HACK: jedi type hinting. Need to have non-obvious condition
             self.db = SQLDatabaseController()
-        self.fpath_to_db = {}
         assert (
             re.search('[0-9]', tablename) is None
         ), 'tablename=%r cannot contain numbers' % (tablename,)

--- a/wbia/dtool/depcache_table.py
+++ b/wbia/dtool/depcache_table.py
@@ -1910,12 +1910,18 @@ class DependencyCacheTable(
 
         self._hack_chunk_cache = None
 
-    # @profile
+    @property
+    def db_name(self):
+        """Name of the database this Table belongs to"""
+        # FIXME (20-Oct-12020) 'fname' is the legacy name, but can't be changed just yet
+        #       as its fairly intertwined in the registration decorator code.
+        return self.fname
+
     def initialize(self, _debug=None):
         """
         Ensures the SQL schema for this cache table
         """
-        self.db = self.depc.fname_to_db[self.fname]
+        self.db = self.depc.get_db_by_name(self.db_name)
         # logger.info('Checking sql for table=%r' % (self.tablename,))
         if not self.db.has_table(self.tablename):
             logger.debug('Initializing table=%r' % (self.tablename,))

--- a/wbia/dtool/depcache_table.py
+++ b/wbia/dtool/depcache_table.py
@@ -1956,6 +1956,8 @@ class DependencyCacheTable(
         self.default_to_unpack = default_to_unpack
         self.vectorized = vectorized
         self.taggable = taggable
+        #: Flag to enable the deletion of external files on associated SQL row deletion.
+        self.rm_extern_on_delete = rm_extern_on_delete
 
         # XXX (20-Oct-12020) It's not clear if these attributes are absolutely necessary.
         self.chunksize = chunksize
@@ -1964,8 +1966,6 @@ class DependencyCacheTable(
         self.isinteractive = isinteractive
         self._asobject = asobject
         self.default_onthefly = default_onthefly
-        # SQL Internals
-        self.rm_extern_on_delete = rm_extern_on_delete
         # Update internals
         self.parent_col_attrs = self._infer_parentcol()
         self.data_col_attrs = self._infer_datacol()

--- a/wbia/dtool/depcache_table.py
+++ b/wbia/dtool/depcache_table.py
@@ -1965,7 +1965,6 @@ class DependencyCacheTable(
         self._asobject = asobject
         self.default_onthefly = default_onthefly
         # SQL Internals
-        self.sqldb_fpath = None
         self.rm_extern_on_delete = rm_extern_on_delete
         # Update internals
         self.parent_col_attrs = self._infer_parentcol()

--- a/wbia/dtool/depcache_table.py
+++ b/wbia/dtool/depcache_table.py
@@ -582,7 +582,7 @@ class _TableDebugHelper(object):
             # ie (depc, parent_ids, config)
             argspec = ut.get_func_argspec(self.preproc_func)
             args = argspec.args
-            if argspec.varargs and argspec.keywords:
+            if argspec.varargs and (hasattr(argspec, 'keywords') and argspec.keywords):
                 assert len(args) == 1, 'varargs and kwargs must have one arg for depcache'
             else:
                 if len(args) < 3:

--- a/wbia/dtool/example_depcache.py
+++ b/wbia/dtool/example_depcache.py
@@ -4,13 +4,19 @@ CommandLine:
     python -m dtool.example_depcache --exec-dummy_example_depcacahe --show
     python -m dtool.depcache_control --exec-make_graph --show
 """
+from pathlib import Path
+from os.path import join
+
 import utool as ut
 import numpy as np
 import uuid
-from os.path import join, dirname
 from six.moves import zip
+
 from wbia.dtool import depcache_control
 from wbia import dtool
+
+
+HERE = Path(__file__).parent.resolve()
 
 
 if False:
@@ -38,10 +44,11 @@ class DummyController:
     """Just enough (IBEIS) controller to make the dependency cache examples work"""
 
     def __init__(self, cache_dpath):
-        self.cache_dpath = cache_dpath
+        self.cache_dpath = Path(cache_dpath)
+        self.cache_dpath.mkdir(exist_ok=True)
 
     def make_cache_db_uri(self, name):
-        return f"sqlite:///{self.cache_dpath}/{name}.sqlite"
+        return f'sqlite:///{self.cache_dpath}/{name}.sqlite'
 
     def get_cachedir(self):
         return self.cache_dpath
@@ -233,13 +240,10 @@ def testdata_depc(fname=None):
     def get_root_uuid(aid_list):
         return ut.lmap(ut.hashable_to_uuid, aid_list)
 
-    # put the test cache in the dtool repo
-    dtool_repo = dirname(ut.get_module_dir(dtool))
-    cache_dpath = join(dtool_repo, 'DEPCACHE')
-
     if not fname:
         fname = dummy_root
 
+    cache_dpath = HERE / 'DEPCACHE'
     controller = DummyController(cache_dpath)
     depc = dtool.DependencyCache.as_named(
         controller,

--- a/wbia/dtool/example_depcache.py
+++ b/wbia/dtool/example_depcache.py
@@ -34,6 +34,19 @@ if False:
             yield 'dummy'
 
 
+class DummyController:
+    """Just enough (IBEIS) controller to make the dependency cache examples work"""
+
+    def __init__(self, cache_dpath):
+        self.cache_dpath = cache_dpath
+
+    def make_cache_db_uri(self, name):
+        return f"sqlite:///{self.cache_dpath}/{name}.sqlite"
+
+    def get_cachedir(self):
+        return self.cache_dpath
+
+
 class DummyKptsConfig(dtool.Config):
     def get_param_info_list(self):
         return [
@@ -224,12 +237,16 @@ def testdata_depc(fname=None):
     dtool_repo = dirname(ut.get_module_dir(dtool))
     cache_dpath = join(dtool_repo, 'DEPCACHE')
 
-    depc = dtool.DependencyCache(
-        root_tablename=dummy_root,
-        default_fname=fname,
-        cache_dpath=cache_dpath,
-        get_root_uuid=get_root_uuid,
-        # root_asobject=root_asobject,
+    if not fname:
+        fname = dummy_root
+
+    controller = DummyController(cache_dpath)
+    depc = dtool.DependencyCache.as_named(
+        controller,
+        fname,
+        get_root_uuid,
+        table_name=dummy_root,
+        root_getters=None,
         use_globals=False,
     )
 

--- a/wbia/dtool/example_depcache.py
+++ b/wbia/dtool/example_depcache.py
@@ -725,8 +725,8 @@ def dummy_example_depcacahe():
     req.execute()
 
     # ut.InstanceList(
-    db = list(depc.fname_to_db.values())[0]
-    # db_list = ut.InstanceList(depc.fname_to_db.values())
+    db = list(depc._db_by_name.values())[0]
+    # db_list = ut.InstanceList(depc._db_by_name.values())
     # db_list.print_table_csv('config', exclude_columns='config_strid')
 
     print('config table')

--- a/wbia/dtool/example_depcache.py
+++ b/wbia/dtool/example_depcache.py
@@ -245,7 +245,7 @@ def testdata_depc(fname=None):
 
     cache_dpath = HERE / 'DEPCACHE'
     controller = DummyController(cache_dpath)
-    depc = dtool.DependencyCache.as_named(
+    depc = dtool.DependencyCache(
         controller,
         fname,
         get_root_uuid,

--- a/wbia/dtool/example_depcache2.py
+++ b/wbia/dtool/example_depcache2.py
@@ -21,7 +21,7 @@ def _depc_factory(name, cache_dir):
     """
     cache_dpath = HERE / cache_dir
     controller = DummyController(cache_dpath)
-    depc = DependencyCache.as_named(
+    depc = DependencyCache(
         controller,
         name,
         ut.identity,

--- a/wbia/dtool/example_depcache2.py
+++ b/wbia/dtool/example_depcache2.py
@@ -86,20 +86,20 @@ def testdata_depc3(in_memory=True):
         >>> ut.show_if_requested()
     """
     from wbia import dtool
+    from wbia.dtool.example_depcache import DummyController
 
     # put the test cache in the dtool repo
     dtool_repo = dirname(ut.get_module_dir(dtool))
     cache_dpath = join(dtool_repo, 'DEPCACHE3')
 
-    # FIXME: this only puts the sql files in memory
-    default_fname = ':memory:' if in_memory else None
-
+    controller = DummyController(cache_dpath)
     root = 'annot'
-    depc = dtool.DependencyCache(
-        root_tablename=root,
-        get_root_uuid=ut.identity,
-        default_fname=default_fname,
-        cache_dpath=cache_dpath,
+    depc = dtool.DependencyCache.as_named(
+        controller,
+        root,
+        ut.identity,
+        table_name=None,
+        root_getters=None,
         use_globals=False,
     )
 
@@ -156,20 +156,20 @@ def testdata_depc4(in_memory=True):
         >>> ut.show_if_requested()
     """
     from wbia import dtool
+    from wbia.dtool.example_depcache import DummyController
 
     # put the test cache in the dtool repo
     dtool_repo = dirname(ut.get_module_dir(dtool))
     cache_dpath = join(dtool_repo, 'DEPCACHE3')
 
-    # FIXME: this only puts the sql files in memory
-    default_fname = ':memory:' if in_memory else None
-
+    controller = DummyController(cache_dpath)
     root = 'annot'
-    depc = dtool.DependencyCache(
-        root_tablename=root,
-        get_root_uuid=ut.identity,
-        default_fname=default_fname,
-        cache_dpath=cache_dpath,
+    depc = dtool.DependencyCache.as_named(
+        controller,
+        root,
+        ut.identity,
+        table_name=None,
+        root_getters=None,
         use_globals=False,
     )
 
@@ -202,20 +202,23 @@ def testdata_depc4(in_memory=True):
 
 def testdata_custom_annot_depc(dummy_dependencies, in_memory=True):
     from wbia import dtool
+    from wbia.dtool.example_depcache import DummyController
 
     # put the test cache in the dtool repo
     dtool_repo = dirname(ut.get_module_dir(dtool))
     cache_dpath = join(dtool_repo, 'DEPCACHE5')
-    # FIXME: this only puts the sql files in memory
-    default_fname = ':memory:' if in_memory else None
+
+    controller = DummyController(cache_dpath)
     root = 'annot'
-    depc = dtool.DependencyCache(
-        root_tablename=root,
-        get_root_uuid=ut.identity,
-        default_fname=default_fname,
-        cache_dpath=cache_dpath,
+    depc = dtool.DependencyCache.as_named(
+        controller,
+        root,
+        ut.identity,
+        table_name=None,
+        root_getters=None,
         use_globals=False,
     )
+
     # ----------
     register_dummy_config = depc_34_helper(depc)
 

--- a/wbia/dtool/example_depcache2.py
+++ b/wbia/dtool/example_depcache2.py
@@ -1,9 +1,35 @@
 # -*- coding: utf-8 -*-
-import utool as ut
+from pathlib import Path
 
-# import numpy as np
-from os.path import join, dirname
+import utool as ut
 from six.moves import zip
+
+from wbia.dtool.depcache_control import DependencyCache
+from wbia.dtool.example_depcache import DummyController
+
+
+HERE = Path(__file__).parent.resolve()
+
+
+def _depc_factory(name, cache_dir):
+    """DependencyCache factory for the examples
+
+    Args:
+        name (str): name of the cache (e.g. 'annot')
+        cache_dir (str): name of the cache directory
+
+    """
+    cache_dpath = HERE / cache_dir
+    controller = DummyController(cache_dpath)
+    depc = DependencyCache.as_named(
+        controller,
+        name,
+        ut.identity,
+        table_name=None,
+        root_getters=None,
+        use_globals=False,
+    )
+    return depc
 
 
 def depc_34_helper(depc):
@@ -85,23 +111,7 @@ def testdata_depc3(in_memory=True):
         >>> #depc['viewpoint_classification'].show_input_graph()
         >>> ut.show_if_requested()
     """
-    from wbia import dtool
-    from wbia.dtool.example_depcache import DummyController
-
-    # put the test cache in the dtool repo
-    dtool_repo = dirname(ut.get_module_dir(dtool))
-    cache_dpath = join(dtool_repo, 'DEPCACHE3')
-
-    controller = DummyController(cache_dpath)
-    root = 'annot'
-    depc = dtool.DependencyCache.as_named(
-        controller,
-        root,
-        ut.identity,
-        table_name=None,
-        root_getters=None,
-        use_globals=False,
-    )
+    depc = _depc_factory('annot', 'DEPCACHE3')
 
     # ----------
     # dummy_cols = dict(colnames=['data'], coltypes=[np.ndarray])
@@ -155,23 +165,7 @@ def testdata_depc4(in_memory=True):
         >>> #depc['viewpoint_classification'].show_input_graph()
         >>> ut.show_if_requested()
     """
-    from wbia import dtool
-    from wbia.dtool.example_depcache import DummyController
-
-    # put the test cache in the dtool repo
-    dtool_repo = dirname(ut.get_module_dir(dtool))
-    cache_dpath = join(dtool_repo, 'DEPCACHE3')
-
-    controller = DummyController(cache_dpath)
-    root = 'annot'
-    depc = dtool.DependencyCache.as_named(
-        controller,
-        root,
-        ut.identity,
-        table_name=None,
-        root_getters=None,
-        use_globals=False,
-    )
+    depc = _depc_factory('annot', 'DEPCACHE4')
 
     # ----------
     # dummy_cols = dict(colnames=['data'], coltypes=[np.ndarray])
@@ -201,23 +195,7 @@ def testdata_depc4(in_memory=True):
 
 
 def testdata_custom_annot_depc(dummy_dependencies, in_memory=True):
-    from wbia import dtool
-    from wbia.dtool.example_depcache import DummyController
-
-    # put the test cache in the dtool repo
-    dtool_repo = dirname(ut.get_module_dir(dtool))
-    cache_dpath = join(dtool_repo, 'DEPCACHE5')
-
-    controller = DummyController(cache_dpath)
-    root = 'annot'
-    depc = dtool.DependencyCache.as_named(
-        controller,
-        root,
-        ut.identity,
-        table_name=None,
-        root_getters=None,
-        use_globals=False,
-    )
+    depc = _depc_factory('annot', 'DEPCACHE5')
 
     # ----------
     register_dummy_config = depc_34_helper(depc)

--- a/wbia/dtool/sql_control.py
+++ b/wbia/dtool/sql_control.py
@@ -515,7 +515,6 @@ class SQLDatabaseController(object):
                 raise AssertionError('Cannot open a new database in readonly mode')
         # Open the SQL database connection with support for custom types
         # lite.enable_callback_tracebacks(True)
-        # self.fpath = ':memory:'
 
         # References:
         # http://stackoverflow.com/questions/10205744/opening-sqlite3-database-from-python-in-read-only-mode


### PR DESCRIPTION
This changeset attempts to remove the filesystem ties from the DependencyCache logic. The overarching intention is to abstract the naming of the objects so that they might be used with either SQLite or Postgres.

By switching to a name rather than a filename we open the Dependency Cache to a service based paradigm (one of which could be a filesystem based service).

The changes attempt to push the database connection URI creation handling up into the scope of the (IBEIS) Controller. The controller has information about service connections. It can produce informed decisions without needing cascade all the necessary bits down the chain of objects. The changes around this concept are not complete, but this is a start in the direction of lifting configuration up rather than having it scattered throughout.

---

This changes one depcache location of `smk/smk_agg_rvecs` to `smk__smk_agg_rvecs`. I choose not to fix this at this time because I have a feeling followup changes are going to change it anyhow. Also, I'd like to enforce not using paths in the names because that's not going to translate well for postgres. So I'm basically punting on this for the moment. 