### PR TITLE
Fix the containers entrypoint

### DIFF
--- a/devops/Dockerfile
+++ b/devops/Dockerfile
@@ -98,9 +98,9 @@ STOPSIGNAL SIGTERM
 # Port for the web server
 EXPOSE 5000
 
-ENTRYPOINT ["/bin/entrypoint", "/virtualenv/env3/bin/python -m wbia.dev --dbdir /data/db --logdir /data/db/logs --web --containerized --production"]
+ENTRYPOINT ["/bin/entrypoint"]
 
 ##########################################################################################
 FROM org.wildme.wbia.install as org.wildme.wbia.configure
 
-CMD []
+CMD ["/virtualenv/env3/bin/python -m wbia.dev --dbdir /data/db --logdir /data/db/logs --web --containerized --production"]


### PR DESCRIPTION
Reference the entry-point script but not the default command. Instead
put the default command as the CMD value. This allows the user to
override the command without overriding the entrypoint.

Think of the entrypoint as a decorator function. In some cases we want
to run a slightly different command, but we still want the same
general behavior.