### PR TITLE
Nightly workflow and runtime container updates

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -13,6 +13,11 @@ fi
 
 echo "*** $0 --- progressing to main execution"
 
-# Catch all for CMD or 'command' in docker-compose
-# Executes as `wbia` with PID 1
-exec gosu wbia:wbia $@
+# Supply EXEC_PRIVILEGED=1 to run your given command as the privileged user.
+if [ $EXEC_PRIVILEGED ]; then
+    exec "$@"
+else
+    # Catch all for CMD or 'command' in docker-compose
+    # Executes as `wbia` with PID 1
+    exec gosu wbia:wbia "$@"
+fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,11 @@ on:
   pull_request:
     paths:
       - '.github/workflows/nightly.yml'
+      # Include any change to the development containers
       - 'devops/**'
+      # Include changes to the runtime container or assets
+      - 'Dockerfile'
+      - '.dockerfiles/*'
 
 jobs:
   devops:


### PR DESCRIPTION
Firstly, sorry to lump these two commits together, but I figured it's better than submitting them separately, which would require the nightly job to run twice (40mins each run).

The first commit is simply to trigger the build on change to the `Dockerfile` or `.dockerfiles/*` files.

The second change is a small amendment that may or may not stick around. I'd also like to use the container on occasion to do operations that require the privileged runtime, but I also don't want to override the entrypoint, because I'd like to use the goodness in the entrypoint. So, simple fix is to add a flag to be able to run the given command as the privileged user. A better solution can be put in place later (maybe using `source`).