### PR TITLE
Fix request_IBEISController caching code per dbdir

### DIFF
--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -255,6 +255,7 @@ def request_IBEISController(
         >>> print(result)
     """
     global __IBEIS_CONTROLLER_CACHE__
+    dbdir = str(dbdir)
 
     if use_cache and dbdir in __IBEIS_CONTROLLER_CACHE__:
         if verbose:


### PR DESCRIPTION
We cache `IBEISController` based on `dbdir` but `dbdir` is sometimes
string but sometimes `PosixPath` so it wasn't returning the cached
controller.  Always cast `dbdir` to string before using it in
`request_IBEISController`.