### PR TITLE
Remove _init_config

### DIFF
--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -369,7 +369,6 @@ class IBEISController(BASE_CLASS):
             request_dbversion=request_dbversion,
             request_stagingversion=request_stagingversion,
         )
-        ibs._init_config()
         if not ut.get_argflag('--noclean') and not ibs.readonly:
             # ibs._init_burned_in_species()
             ibs._clean_species()


### PR DESCRIPTION
This method call essentially initializes the default database
species.

The only other thing it did was to re-init/reset the
tablecache. That is also called in `_initialize_self`.

Tests pass, so no need to keep it hanging around. For now I'm leaving
the `_init_config` definition. It'll get vaccumed in a cleanup phase.