### PR TITLE
Fix tests associated with removal of primary species

### DIFF
--- a/wbia/algo/graph/mixin_wbia.py
+++ b/wbia/algo/graph/mixin_wbia.py
@@ -437,9 +437,9 @@ class IBEISIO(object):
             >>> print(result)
                 old_name       new_name
             aid
-            1     06_410  IBEIS_PZ_0042
-            5     07_061         06_410
-            6     07_061         06_410
+            1     06_410  IBEIS_UNKNOWN_0042
+            5     07_061              06_410
+            6     07_061              06_410
 
         Doctest:
             >>> from wbia.algo.graph.mixin_wbia import *  # NOQA

--- a/wbia/other/ibsfuncs.py
+++ b/wbia/other/ibsfuncs.py
@@ -3066,10 +3066,10 @@ def make_next_name(ibs, num=None, str_format=2, species_text=None, location_text
         >>> result = ut.repr4(names)
         >>> print(result)
         (
-            ['IBEIS_UNKNOWN_0008', 'IBEIS_PZ_0042', 'IBEIS_UNKNOWN_0004', 'IBEIS_GZ_0008'],
-            ['IBEIS_PZ_0042', 'IBEIS_PZ_0043', 'IBEIS_PZ_0044', 'IBEIS_PZ_0045', 'IBEIS_PZ_0046'],
-            ['IBEIS_PZ_0044', 'IBEIS_PZ_0045', 'IBEIS_PZ_0046', 'IBEIS_PZ_0047', 'IBEIS_PZ_0048'],
-            ['IBEIS_PZ_0042', 'IBEIS_PZ_0043', 'IBEIS_PZ_0044', 'IBEIS_PZ_0045', 'IBEIS_PZ_0046'],
+            ['IBEIS_UNKNOWN_0008', 'IBEIS_UNKNOWN_0042', 'IBEIS_UNKNOWN_0004', 'IBEIS_GZ_0008'],
+            ['IBEIS_UNKNOWN_0042', 'IBEIS_UNKNOWN_0043', 'IBEIS_UNKNOWN_0044', 'IBEIS_UNKNOWN_0045', 'IBEIS_UNKNOWN_0046'],
+            ['IBEIS_UNKNOWN_0044', 'IBEIS_UNKNOWN_0045', 'IBEIS_UNKNOWN_0046', 'IBEIS_UNKNOWN_0047', 'IBEIS_UNKNOWN_0048'],
+            ['IBEIS_UNKNOWN_0042', 'IBEIS_UNKNOWN_0043', 'IBEIS_UNKNOWN_0044', 'IBEIS_UNKNOWN_0045', 'IBEIS_UNKNOWN_0046'],
         )
 
     """


### PR DESCRIPTION
I believe these tests were failing because of our removal of the
primary species logic in 2455fa7 & fbb57fe54721a96d436eb268a555f75d22a1637a before that.