### PR TITLE
Catch StopIteration in /turk/identification/lnbnn

### DIFF
--- a/wbia/tests/web/test_routes.py
+++ b/wbia/tests/web/test_routes.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import wbia
+
+
+def test_turk_identification_no_more_to_review():
+    with wbia.opendb_bg_web('testdb2', managed=True) as web_ibs:
+        resp = web_ibs.get('/turk/identification/lnbnn/')
+        assert resp.status_code == 200
+        assert b'Traceback' not in resp.content, resp.content
+        assert b'<h1>No more to review!</h1>' in resp.content, resp.content

--- a/wbia/web/routes.py
+++ b/wbia/web/routes.py
@@ -4054,7 +4054,10 @@ def turk_identification(
                 review_cfg[
                     'max_num'
                 ] = global_feedback_limit  # Controls the top X to be randomly sampled and displayed to all concurrent users
-                values = query_object.pop()
+                try:
+                    values = query_object.pop()
+                except StopIteration as e:
+                    return appf.template(None, 'simple', title=str(e).capitalize())
                 (review_aid1_list, review_aid2_list), review_confidence = values
                 review_aid1_list = [review_aid1_list]
                 review_aid2_list = [review_aid2_list]

--- a/wbia/web/templates/simple.html
+++ b/wbia/web/templates/simple.html
@@ -1,0 +1,7 @@
+{% extends "layout.html" %}
+{% block content %}
+  <div class="jumbotron">
+    <h1>{{ title }}</h1>
+    <p class="lead">{{ content }}</p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
When there's no more to review, `/turk/identification/lnbnn/` returns
some json with traceback:

```
{"status": {"success": false, "code": 400, "message": "Route error, Python Exception thrown: 'no more to review!'", "cache": -1}, "response": "Traceback (most recent call last):
  File \"/wbia/wbia-utool/utool/util_dev.py\", line 3652, in pop
    val, key = self._heappop(_heap)
IndexError: index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/wbia/wildbook-ia/wbia/algo/graph/mixin_priority.py\", line 290, in pop
    edge, priority = infr._pop()
  File \"/wbia/wildbook-ia/wbia/algo/graph/mixin_priority.py\", line 37, in _pop
    (e, (p, _)) = infr.queue.pop(*args)
  File \"/wbia/wbia-utool/utool/util_dev.py\", line 3658, in pop
    raise IndexError('queue is empty')
IndexError: queue is empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File \"/wbia/wildbook-ia/wbia/control/controller_inject.py\", line 1217, in translated_call
    result = func(**kwargs)
  File \"/wbia/wildbook-ia/wbia/web/routes.py\", line 4043, in turk_identification
    values = query_object.pop()
  File \"/wbia/wildbook-ia/wbia/algo/graph/mixin_priority.py\", line 292, in pop
    raise StopIteration('no more to review!')
StopIteration: no more to review!
```

Instead, return a message saying "no more to review!"

---

This error is in both `develop` and `sql/optimized-queries`.