### PR TITLE
Downgrade scikit-learn to 0.23.2

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -41,7 +41,7 @@ pyzmq>=14.7.0
 
 requests>=2.5.0
 scikit-image>=0.12.3
-scikit-learn>=0.17.1
+scikit-learn>=0.17.1,<0.24.0
 scipy>=0.18.0
 
 sentry-sdk>=0.10.2


### PR DESCRIPTION
Tests are failing after the upgrade to scikit-learn 0.24.0:

```
<!!! EXCEPTION !!!>
Traceback (most recent call last):
  File "/wbia/wbia-utool/utool/util_io.py", line 357, in load_cPkl
    data = FixRenamedUnpickler(file_).load()
UnicodeDecodeError: 'ascii' codec can't decode byte 0x98 in position 0: ordinal not in range(128)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/wbia/wildbook-ia/wbia/dtool/depcache_table.py", line 1750, in _chunk_compute_dirty_rows
    config,
  File "/wbia/wildbook-ia/wbia/dtool/depcache_table.py", line 1680, in _compute_dirty_rows
    proptup_gen = list(proptup_gen)
  File "/wbia/wildbook-ia/wbia/core_annots.py", line 805, in compute_probchip
    grouped_probchips.append(list(gen))
  File "/wbia/wildbook-ia/wbia/core_annots.py", line 831, in cnn_probchips
    for chunk in ut.ichunks(mask_gen, 256):
  File "/wbia/wbia-utool/utool/util_iter.py", line 439, in ichunks_noborder
    for chunk in chunks_with_sentinals:
  File "/wbia/wbia-plugin-cnn/wbia_cnn/_plugin.py", line 1002, in generate_species_background
    model_state = ut.load_cPkl(model_state_fpath)
  File "/wbia/wbia-utool/utool/util_io.py", line 362, in load_cPkl
    data = FixRenamedUnpickler(file_, encoding='latin1').load()
  File "/wbia/wbia-utool/utool/util_io.py", line 276, in find_class
    return super(FixRenamedUnpickler, self).find_class(module, name)
ModuleNotFoundError: No module named 'sklearn.preprocessing.label'
```

The module is `sklearn.preprocessing.label` and the name is
`LabelEncoder`.  It has been moved to `sklearn.preprocessing`.  The file
that failed to unpickle is
`/root/.cache/wbia_cnn/background.candidacy.zebra_plains.pkl`.

We'll fix it later.