### PR TITLE
Add test to make sure uuid is stored as little endian

### DIFF
--- a/wbia/tests/dtool/test_types.py
+++ b/wbia/tests/dtool/test_types.py
@@ -193,3 +193,20 @@ def test_uuid(db):
     results = db.execute(stmt)
     selected_value = results.fetchone()[0]
     assert selected_value == insert_value
+
+
+def test_le_uuid(db):
+    db.execute(text('CREATE TABLE test(x UUID)'))
+
+    # Insert a uuid value but explicitly stored as little endian
+    # (the way uuids were stored before sqlalchemy)
+    insert_value = uuid.uuid4()
+    stmt = text('INSERT INTO test(x) VALUES (:x)')
+    db.execute(stmt, x=insert_value.bytes_le)
+
+    # Query for the value
+    stmt = text('SELECT x FROM test')
+    stmt = stmt.columns(x=UUID)
+    results = db.execute(stmt)
+    selected_value = results.fetchone()[0]
+    assert selected_value == insert_value


### PR DESCRIPTION
Before sqlalchemy, we were storing uuid as bytes in little endian order.
We have no tests to make sure that those existing uuids are being read
back out correctly so just adding one now.

I checked that this test failed without commit "49f3fa77f" (Existing
databases storer UUIDs with little-endian encoding), so it is testing
the right thing.