### PR TITLE
Fix API calls to IBEISController methods that now use 'self'

### DIFF
--- a/wbia/control/controller_inject.py
+++ b/wbia/control/controller_inject.py
@@ -590,7 +590,7 @@ def translate_wbia_webcall(func, *args, **kwargs):
         output = func(**kwargs)
     except TypeError:
         try:
-            output = func(ibs=ibs, **kwargs)
+            output = func(ibs, **kwargs)
         except WebException:
             raise
         except Exception as ex2:  # NOQA


### PR DESCRIPTION
Fixes several routes on the IBEISController from the change in 08ad98e141f304fad5593d7e5d04117416e049c0