### PR TITLE
Upgrade scikit-learn to 0.24.0 and wbia-utool to 3.3.3

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -41,7 +41,7 @@ pyzmq>=14.7.0
 
 requests>=2.5.0
 scikit-image>=0.12.3
-scikit-learn>=0.17.1,<0.24.0
+scikit-learn>=0.24.0
 scipy>=0.18.0
 
 sentry-sdk>=0.10.2
@@ -70,5 +70,5 @@ wbia-pyflann >= 3.1.0
 wbia-pyhesaff >= 3.0.2
 wbia-pyrf >= 3.0.0
 
-wbia-utool >= 3.3.1
+wbia-utool >= 3.3.3
 wbia-vtool >= 3.2.1

--- a/wbia/algo/smk/smk_pipeline.py
+++ b/wbia/algo/smk/smk_pipeline.py
@@ -571,8 +571,7 @@ def testdata_smk(*args, **kwargs):
     # import sklearn.model_selection
     ibs, aid_list = wbia.testdata_aids(defaultdb='PZ_MTEST')
     nid_list = np.array(ibs.annots(aid_list).nids)
-    rng = ut.ensure_rng(0)
-    xvalkw = dict(n_splits=4, shuffle=False, random_state=rng)
+    xvalkw = dict(n_splits=4, shuffle=False)
 
     skf = sklearn.model_selection.StratifiedKFold(**xvalkw)
     train_idx, test_idx = six.next(skf.split(aid_list, nid_list))

--- a/wbia/algo/verif/sklearn_utils.py
+++ b/wbia/algo/verif/sklearn_utils.py
@@ -512,11 +512,9 @@ def classification_report2(
     # and BM * MK MCC?
 
     def matthews_corrcoef(y_true, y_pred, sample_weight=None):
-        from sklearn.metrics.classification import (
-            _check_targets,
-            LabelEncoder,
-            confusion_matrix,
-        )
+        from sklearn.preprocessing import LabelEncoder
+        from sklearn.metrics import confusion_matrix
+        from sklearn.metrics._classification import _check_targets
 
         y_type, y_true, y_pred = _check_targets(y_true, y_pred)
         if y_type not in {'binary', 'multiclass'}:


### PR DESCRIPTION
wbia-utool 3.3.3 includes changes to use scikit-learn 0.24.0.

scikit-learn 0.24.0 has changed the way StratifiedKFold split works and we can
no longer specify `shuffle=True` and `random_state=rng`:

```
DOCTEST TRACEBACK
Traceback (most recent call last):
  File "/virtualenv/env3/lib/python3.7/site-packages/xdoctest/doctest_example.py", line 598, in run
    exec(code, test_globals)
  File "<doctest:/wbia/wildbook-ia/wbia/algo/smk/match_chips5.py::EstimatorRequest.shallowcopy:0>", line rel: 5, abs: 49, in <module>
    >>> wbia, smk, qreq_ = testdata_smk()
  File "/wbia/wildbook-ia/wbia/algo/smk/smk_pipeline.py", line 577, in testdata_smk
    skf = sklearn.model_selection.StratifiedKFold(**xvalkw)
  File "/virtualenv/env3/lib/python3.7/site-packages/sklearn/utils/validation.py", line 63, in inner_f
    return f(*args, **kwargs)
  File "/virtualenv/env3/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 637, in __init__
    random_state=random_state)
  File "/virtualenv/env3/lib/python3.7/site-packages/sklearn/utils/validation.py", line 63, in inner_f
    return f(*args, **kwargs)
  File "/virtualenv/env3/lib/python3.7/site-packages/sklearn/model_selection/_split.py", line 291, in __init__
    'Setting a random_state has no effect since shuffle is '
ValueError: Setting a random_state has no effect since shuffle is False. You should leave random_state to its default (None), or set shuffle=True.
DOCTEST REPRODUCTION
CommandLine:
    pytest /wbia/wildbook-ia/wbia/algo/smk/match_chips5.py::EstimatorRequest.shallowcopy:0
```

So I removed `random_state`.

Also update imports after scikit-learn moved classes and modules around.