### PR TITLE
Fix db.get and db.get_where_eq when id is not integer

### DIFF
--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -78,12 +78,12 @@ def image_src_api(rowid=None, thumbnail=False, fresh=False, **kwargs):
     Returns the image file of image <gid>
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
         ...     resp = web_ibs.send_wbia_request('/api/image/src/1/', type_='get', json=False)
         >>> print(resp)
+        b'\xff\xd8\xff\xe0\x00\x10JFIF...
 
     RESTful:
         Method: GET


### PR DESCRIPTION
The sql statement itself works, but the python code to extract the
results wasn't working correctly.  It uses a dict to look up the result
for each id, but when the id is a string but the column is actually an
int, the code fails to look up the result.

Use the column type processors to transform the id to the same as what's
returned in the sql query to make the look up work.

The `image_src_api` test used to return 200 OK but with:

```
{
    "status": {
        "success": false,
        "code": 400,
        "message": "Route error, Python Exception thrown: 'image path should not be None'",
        "cache": -1
    },
    "response": "Traceback (most recent call last):\\n  File \\"/wbia/wildbook-ia/wbia/control/controller_inject.py\\", line 1217, in translated_call\\n    result = func(**kwargs)\\n  File \\"/wbia/wildbook-ia/wbia/web/apis.py\\", line 108, in image_src_api\\n    assert gpath is not None, 'image path should not be None'\\nAssertionError: image path should not be None\\n"
}
```

Change the test so it actually asserts the content.