### PR TITLE
Fix web tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           mkdir -p data/work
           python -m wbia --set-workdir data/work --preload-exit
-          pytest --slow
+          pytest --slow --web-tests
 
   on-failure:
     # This is not in the 'test' job itself because it would otherwise notify once per matrix combination.

--- a/wbia/__init__.py
+++ b/wbia/__init__.py
@@ -68,7 +68,7 @@ try:
         main_loop,
         opendb,
         opendb_in_background,
-        opendb_bg_web,
+        opendb_with_web,
     )
     from wbia.control.IBEISControl import IBEISController
     from wbia.algo.hots.query_request import QueryRequest

--- a/wbia/control/IBEISControl.py
+++ b/wbia/control/IBEISControl.py
@@ -1153,20 +1153,15 @@ class IBEISController(BASE_CLASS):
     @register_api('/log/current/', methods=['GET'])
     def get_current_log_text(self):
         r"""
-        CommandLine:
-            python -m wbia.control.IBEISControl --exec-get_current_log_text
-            python -m wbia.control.IBEISControl --exec-get_current_log_text --domain http://52.33.105.88
 
         Example:
             >>> # xdoctest: +REQUIRES(--web-tests)
-            >>> from wbia.control.IBEISControl import *  # NOQA
             >>> import wbia
-            >>> import wbia.web
-            >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-            ...     resp = web_ibs.send_wbia_request('/log/current/', 'get')
-            >>> print('\n-------Logs ----: \n' )
-            >>> print(resp)
-            >>> print('\nL____ END LOGS ___\n')
+            >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+            ...     resp = client.get('/log/current/')
+            >>> resp.json
+            {'status': {'success': True, 'code': 200, 'message': '', 'cache': -1}, 'response': None}
+
         """
         text = ut.get_current_log_text()
         return text

--- a/wbia/control/controller_inject.py
+++ b/wbia/control/controller_inject.py
@@ -489,35 +489,20 @@ def translate_wbia_webcall(func, *args, **kwargs):
     Returns:
         tuple: (output, True, 200, None, jQuery_callback)
 
-    CommandLine:
-        python -m wbia.control.controller_inject --exec-translate_wbia_webcall
-        python -m wbia.control.controller_inject --exec-translate_wbia_webcall --domain http://52.33.105.88
-
     Example:
         >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.control.controller_inject import *  # NOQA
         >>> import wbia
-        >>> import time
-        >>> import wbia.web
-        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     aids = web_ibs.send_wbia_request('/api/annot/', 'get')
-        ...     uuid_list = web_ibs.send_wbia_request('/api/annot/uuids/', aid_list=aids, json=False)
-        ...     failrsp = web_ibs.send_wbia_request('/api/annot/uuids/', json=False)
-        ...     failrsp2 = web_ibs.send_wbia_request('/api/query/chips/simple_dict//', 'get', qaid_list=[0], daid_list=[0], json=False)
-        ...     log_text = web_ibs.send_wbia_request('/api/query/chips/simple_dict/', 'get', qaid_list=[0], daid_list=[0], json=False)
-        >>> time.sleep(.1)
-        >>> print('\n---\nuuid_list = %r' % (uuid_list,))
-        >>> print('\n---\nfailrsp =\n%s' % (failrsp,))
-        >>> print('\n---\nfailrsp2 =\n%s' % (failrsp2,))
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     aids = client.get('/api/annot/').json
+        ...     failrsp = client.post('/api/annot/uuids/')
+        ...     failrsp2 = client.get('/api/query/chips/simple_dict//', data={'qaid_list': [0], 'daid_list': [0]})
+        ...     log_text = client.get('/api/query/chips/simple_dict/', data={'qaid_list': [0], 'daid_list': [0]})
+        >>> print('\n---\nfailrsp =\n%s' % (failrsp.data,))
+        >>> print('\n---\nfailrsp2 =\n%s' % (failrsp2.data,))
         >>> print('Finished test')
+        Finished test
 
-    Ignore:
-        app = get_flask_app()
-        with app.app_context():
-            #ibs = wbia.opendb('testdb1')
-            func = ibs.get_annot_uuids
-            args = tuple()
-            kwargs = dict()
     """
     assert len(args) == 0, 'There should not be any args=%r' % (args,)
 

--- a/wbia/core_annots.py
+++ b/wbia/core_annots.py
@@ -2711,7 +2711,9 @@ def get_annot_lrudfb_bools(ibs, aid_list):
             'front' in view,
             'back' in view,
         ]
-        if view is not None else [False] * 6 for view in views
+        if view is not None
+        else [False] * 6
+        for view in views
     ]
     return bool_arrays
 

--- a/wbia/tests/web/test_routes.py
+++ b/wbia/tests/web/test_routes.py
@@ -3,8 +3,8 @@ import wbia
 
 
 def test_turk_identification_no_more_to_review():
-    with wbia.opendb_bg_web('testdb2', managed=True) as web_ibs:
-        resp = web_ibs.get('/turk/identification/lnbnn/')
+    with wbia.opendb_with_web('testdb2') as (ibs, client):
+        resp = client.get('/turk/identification/lnbnn/')
         assert resp.status_code == 200
-        assert b'Traceback' not in resp.content, resp.content
-        assert b'<h1>No more to review!</h1>' in resp.content, resp.content
+        assert b'Traceback' not in resp.data
+        assert b'<h1>No more to review!</h1>' in resp.data

--- a/wbia/web/apis.py
+++ b/wbia/web/apis.py
@@ -80,9 +80,9 @@ def image_src_api(rowid=None, thumbnail=False, fresh=False, **kwargs):
     Example:
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     resp = web_ibs.send_wbia_request('/api/image/src/1/', type_='get', json=False)
-        >>> print(resp)
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/api/image/src/1/')
+        >>> print(resp.data)
         b'\xff\xd8\xff\xe0\x00\x10JFIF...
 
     RESTful:
@@ -136,12 +136,13 @@ def annot_src_api(rowid=None, fresh=False, **kwargs):
 
     Example:
         >>> # xdoctest: +REQUIRES(--slow)
-        >>> # WEB_DOCTEST
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     resp = web_ibs.send_wbia_request('/api/annot/src/1/', type_='get', json=False)
-        >>> print(resp)
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/api/annot/src/1/')
+        >>> print(resp.data)
+        b'\xff\xd8\xff\xe0\x00\x10JFIF...
 
     RESTful:
         Method: GET
@@ -184,12 +185,13 @@ def background_src_api(rowid=None, fresh=False, **kwargs):
 
     Example:
         >>> # xdoctest: +REQUIRES(--slow)
-        >>> # WEB_DOCTEST
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     resp = web_ibs.send_wbia_request('/api/background/src/1/', type_='get', json=False)
-        >>> print(resp)
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/api/background/src/1/')
+        >>> print(resp.data)
+        b'\xff\xd8\xff\xe0\x00\x10JFIF...
 
     RESTful:
         Method: GET
@@ -234,9 +236,10 @@ def image_src_api_json(uuid=None, **kwargs):
         >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     resp = web_ibs.send_wbia_request('/api/image/src/json/0a9bc03d-a75e-8d14-0153-e2949502aba7/', type_='get', json=False)
-        >>> print(resp)
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/api/image/src/json/0a9bc03d-a75e-8d14-0153-e2949502aba7/')
+        >>> print(resp.data)
+        b'\xff\xd8\xff\xe0\x00\x10JFIF...
 
     RESTful:
         Method: GET
@@ -436,37 +439,21 @@ def image_upload_zip(**kwargs):
 @register_api('/api/test/helloworld/', methods=['GET', 'POST', 'DELETE', 'PUT'])
 def hello_world(*args, **kwargs):
     """
-    CommandLine:
-        python -m wbia.web.apis --exec-hello_world:0
-        python -m wbia.web.apis --exec-hello_world:1
 
     Example:
         >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web(browser=True, start_job_queue=False, url_suffix='/api/test/helloworld/?test0=0')  # start_job_queue=False)
-        >>> print('web_ibs = %r' % (web_ibs,))
-        >>> print('Server will run until control c')
-        >>> web_ibs.terminate2()
-
-    Example1:
-        >>> # xdoctest: +REQUIRES(--web-tests)
-        >>> from wbia.web.app import *  # NOQA
-        >>> import wbia
         >>> import requests
         >>> import wbia
-        >>> with wbia.opendb_bg_web('testdb1', start_job_queue=False, managed=True) as web_ibs:
-        ...     web_port = ibs.get_web_port_via_scan()
-        ...     if web_port is None:
-        ...         raise ValueError('IA web server is not running on any expected port')
-        ...     domain = 'http://127.0.0.1:%s' % (web_port, )
-        ...     url = domain + '/api/test/helloworld/?test0=0'
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/api/test/helloworld/?test0=0')
         ...     payload = {
         ...         'test1' : 'test1',
         ...         'test2' : None,  # NOTICE test2 DOES NOT SHOW UP
         ...     }
-        ...     resp = requests.post(url, data=payload)
-        ...     print(resp)
+        ...     resp = client.post('/api/test/helloworld/', data=payload)
+
     """
     logger.info('+------------ HELLO WORLD ------------')
     logger.info('Args: %r' % (args,))

--- a/wbia/web/apis_engine.py
+++ b/wbia/web/apis_engine.py
@@ -262,6 +262,7 @@ def start_identify_annots(
 
     Example:
         >>> # xdoctest: +REQUIRES(--web-tests)
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
         >>> from wbia.web.apis_engine import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
@@ -452,6 +453,7 @@ def start_identify_annots_query(
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
         >>> from wbia.web.apis_engine import *  # NOQA
         >>> import wbia
         >>> #domain = 'localhost'

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -325,6 +325,9 @@ def review_graph_match_html(
 
     Example:
         >>> # xdoctest: +REQUIRES(--web-tests)
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
+        >>> # DISABLE_DOCTEST
+        >>> # Disabled because this test uses opendb_bg_web, which hangs the test runner and leaves zombie processes
         >>> from wbia.web.apis_query import *  # NOQA
         >>> import wbia
         >>> web_ibs = wbia.opendb_bg_web('testdb1')  # , domain='http://52.33.105.88')
@@ -377,6 +380,7 @@ def review_graph_match_html(
 
     Example2:
         >>> # DISABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
         >>> # This starts off using web to get information, but finishes the rest in python
         >>> from wbia.web.apis_query import *  # NOQA
         >>> import wbia

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -1468,13 +1468,12 @@ def query_chips_graph_v2(
         >>> # Open local instance
         >>> ibs = wbia.opendb('PZ_MTEST')
         >>> uuid_list = ibs.annots().uuids[0:10]
-        >>> # Start up the web instance
-        >>> web_ibs = wbia.opendb_bg_web(db='PZ_MTEST', web=True, browser=False)
         >>> data = dict(annot_uuid_list=uuid_list)
-        >>> resp = web_ibs.send_wbia_request('/api/query/graph/v2/', **data)
-        >>> print('resp = %r' % (resp,))
-        >>> #cmdict_list = json_dict['response']
-        >>> #assert 'score_list' in cmdict_list[0]
+        >>> # Start up the web instance
+        >>> with wbia.opendb_with_web(db='PZ_MTEST') as (ibs, client):
+        ...     resp = client.post('/api/query/graph/v2/', data=data)
+        >>> resp.json
+        {'status': {'success': False, 'code': 608, 'message': 'Invalid image and/or annotation UUIDs (0, 1)', 'cache': -1}, 'response': {'invalid_image_uuid_list': [], 'invalid_annot_uuid_list': [[0, 'c544d25f-fd03-5a2d-6611-cd77430ca251']]}}
 
     Example:
         >>> # DEBUG_SCRIPT

--- a/wbia/web/apis_query.py
+++ b/wbia/web/apis_query.py
@@ -544,16 +544,6 @@ def review_graph_match_html(
 
 @register_route('/test/review/query/chip/', methods=['GET'])
 def review_query_chips_test(**kwargs):
-    """
-    CommandLine:
-        python -m wbia.web.apis_query review_query_chips_test --show
-
-    Example:
-        >>> # SCRIPT
-        >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web(
-        >>>     browser=True, url_suffix='/test/review/query/chip/?__format__=true')
-    """
     ibs = current_app.ibs
 
     # the old block curvature dtw

--- a/wbia/web/app.py
+++ b/wbia/web/app.py
@@ -37,14 +37,13 @@ def tst_html_error():
     r"""
     This test will show what our current errors look like
 
-    CommandLine:
-        python -m wbia.web.app --exec-tst_html_error
-
     Example:
-        >>> # DISABLE_DOCTEST
-        >>> from wbia.web.app import *  # NOQA
         >>> import wbia
-        >>> web_ibs = wbia.opendb_bg_web(browser=True, start_job_queue=False, url_suffix='/api/image/imagesettext/?__format__=True')
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/api/image/imagesettext/?__format__=True')
+        >>> print(resp)
+        <Response streamed [500 INTERNAL SERVER ERROR]>
+
     """
     pass
 

--- a/wbia/web/job_engine.py
+++ b/wbia/web/job_engine.py
@@ -162,6 +162,7 @@ def initialize_job_manager(ibs):
 
     Example:
         >>> # DISABLE_DOCTEST
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> ibs = wbia.opendb(defaultdb='testdb1')
@@ -174,24 +175,6 @@ def initialize_job_manager(ibs):
         >>> ibs.close_job_manager()
         >>> print('Closing success.')
 
-    Example:
-        >>> # xdoctest: +REQUIRES(--web-tests)
-        >>> from wbia.web.job_engine import *  # NOQA
-        >>> import wbia
-        >>> import requests
-        >>> with wbia.opendb_bg_web(db='testdb1', managed=True) as web_instance:
-        ...     web_port = ibs.get_web_port_via_scan()
-        ...     if web_port is None:
-        ...         raise ValueError('IA web server is not running on any expected port')
-        ...     baseurl = 'http://127.0.1.1:%s' % (web_port, )
-        ...     _payload = {'image_attrs_list': [], 'annot_attrs_list': []}
-        ...     payload = ut.map_dict_vals(ut.to_json, _payload)
-        ...     resp1 = requests.post(baseurl + '/api/test/helloworld/?f=b', data=payload)
-        ...     #resp2 = requests.post(baseurl + '/api/image/json/', data=payload)
-        ...     #print(resp2)
-        ...     #json_dict = resp2.json()
-        ...     #text = json_dict['response']
-        ...     #print(text)
     """
     ibs.job_manager = ut.DynStruct()
 
@@ -265,6 +248,7 @@ def get_job_id_list(ibs):
 
     Example:
         >>> # xdoctest: +REQUIRES(--web-tests)
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
@@ -317,6 +301,7 @@ def get_job_status(ibs, jobid=None):
 
     Example:
         >>> # xdoctest: +REQUIRES(--web-tests)
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')
@@ -363,7 +348,8 @@ def get_job_metadata(ibs, jobid):
 
     Example:
         >>> # xdoctest: +REQUIRES(--slow)
-        >>> # WEB_DOCTEST
+        >>> # xdoctest: +REQUIRES(--job-engine-tests)
+        >>> # xdoctest: +REQUIRES(--web-tests)
         >>> from wbia.web.job_engine import *  # NOQA
         >>> import wbia
         >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:  # , domain='http://52.33.105.88')

--- a/wbia/web/routes.py
+++ b/wbia/web/routes.py
@@ -3974,11 +3974,6 @@ def check_engine_identification_query_object(
     if current_app.QUERY_OBJECT_JOBID is None:
         current_app.QUERY_OBJECT = None
         current_app.QUERY_OBJECT_JOBID = ibs.start_web_query_all()
-        # import wbia
-        # web_ibs = wbia.opendb_bg_web(dbdir=ibs.dbdir, port=6000)
-        # query_object_jobid = web_ibs.send_wbia_request('/api/engine/query/graph/')
-        # logger.info('query_object_jobid = %r' % (query_object_jobid, ))
-        # current_app.QUERY_OBJECT_JOBID = query_object_jobid
 
     query_object_status_dict = ibs.get_job_status(current_app.QUERY_OBJECT_JOBID)
     args = (
@@ -4018,11 +4013,11 @@ def turk_identification(
         >>> # SCRIPT
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
-        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:
-        ...     resp = web_ibs.get('/turk/identification/lnbnn/')
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/turk/identification/lnbnn/')
         >>> ut.quit_if_noshow()
         >>> import wbia.plottool as pt
-        >>> ut.render_html(resp.content)
+        >>> ut.render_html(resp.data.decode('utf8'))
         >>> ut.show_if_requested()
     """
     from wbia.web import apis_query
@@ -4762,8 +4757,8 @@ def turk_identification_hardcase(*args, **kwargs):
         >>> # SCRIPT
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
-        >>> with wbia.opendb_bg_web('PZ_Master1', managed=True) as web_ibs:
-        ...     resp = web_ibs.get('/turk/identification/hardcase/')
+        >>> with wbia.opendb_with_web('PZ_Master1') as (ibs, client):
+        ...     resp = client.get('/turk/identification/hardcase/')
 
     Ignore:
         import wbia
@@ -4822,11 +4817,11 @@ def turk_identification_graph(
         >>> # SCRIPT
         >>> from wbia.other.ibsfuncs import *  # NOQA
         >>> import wbia
-        >>> with wbia.opendb_bg_web('testdb1', managed=True) as web_ibs:
-        ...     resp = web_ibs.get('/turk/identification/graph/')
+        >>> with wbia.opendb_with_web('testdb1') as (ibs, client):
+        ...     resp = client.get('/turk/identification/graph/')
         >>> ut.quit_if_noshow()
         >>> import wbia.plottool as pt
-        >>> ut.render_html(resp.content)
+        >>> ut.render_html(resp.data.decode('utf8'))
         >>> ut.show_if_requested()
     """
     ibs = current_app.ibs

--- a/wbia/web/test_api.py
+++ b/wbia/web/test_api.py
@@ -87,7 +87,7 @@ def run_test_api():
         python -m wbia.web.test_api --test-run_test_api
 
     Example:
-        >>> # xdoctest: +REQUIRES(--web-tests)
+        >>> # DISABLE_DOCTEST
         >>> from wbia.web.test_api import *  # NOQA
         >>> response = run_test_api()
         >>> print('Server response: %r' % (response, ))
@@ -103,6 +103,8 @@ def run_test_api():
 
     # Get the application port from the background process
     if APPLICATION_PORT is None:
+        # FIXME web_instance is a KillableProcess, not IBEISController,
+        # it doesn't have get_web_port_via_scan
         web_port = web_instance.get_web_port_via_scan()
         if web_port is None:
             raise ValueError('IA web server is not running on any expected port')


### PR DESCRIPTION
❗ Depends on #171

This set of changes introduces a `opendb_with_web` to work similarly to `opendb_bg_web` but without the background process(es).

I had tried to have `opendb_with_web` start the job-engine in the background as processes, but it's still running into the issue of leaving behind zombie processes. Further investigation will need to be done. And maybe even small architectural changes will be needed. For now, the function works great to provide a simple web interface without running the full blown web server as a process.

Some tests have been disabled, while others have been enabled, because there is a change to enable `--web-tests` in CI. Tests that use the job-engine have been disabled for now. The major reason is because of the zombie processes. The other reason is around unknown expectations from returned functions; that is, the doctests as written don't seem to be returning the correctly expected values in some cases. Overall, some of the tests that are now live again have assertions added to them to check for correctness.

This work has been done to resolve testing issues with the `sql/postgres` branch, which will be rebased over this. As of this writing the `sql/postgres` branch with this merged in is passing all tests.